### PR TITLE
fix(desktop): keep the combo a user chose all the way to the cli

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.test.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.test.ts
@@ -274,3 +274,106 @@ describe('useTurnRouting, agent reference', () => {
     expect(result.current.referenceEffort).toBe('high');
   });
 });
+
+describe('useTurnRouting, combo axes', () => {
+  const cursorSession = (defaultModel?: string): Session =>
+    makeSession({
+      providerPreference: {
+        defaultProvider: 'cursor',
+        ...(defaultModel != null && { defaultModel }),
+        allowTurnOverride: true,
+      },
+    });
+
+  it('hands out an effective id and selection that keep the combo', () => {
+    const { result } = renderHook(() => useTurnRouting({ session: cursorSession() }));
+
+    act(() => {
+      result.current.setSelectedModel('composer-2.5-fast');
+    });
+
+    expect(result.current.effectiveModelId).toBe('composer-2.5-fast');
+    expect(result.current.effectiveSelection.toggles?.fast).toBe(true);
+    expect(result.current.effectiveModel).toBe('composer-2.5');
+  });
+
+  it('calls a combo that differs from the reference an override', () => {
+    const { result } = renderHook(() => useTurnRouting({ session: cursorSession() }));
+
+    expect(result.current.isOverridden).toBe(false);
+
+    act(() => {
+      result.current.setSelectedModel('composer-2.5-fast');
+    });
+
+    expect(result.current.isOverridden).toBe(true);
+  });
+
+  it('calls a fast default the default', () => {
+    const { result } = renderHook(() =>
+      useTurnRouting({ session: cursorSession('composer-2.5-fast') }),
+    );
+
+    expect(result.current.effectiveModelId).toBe('composer-2.5-fast');
+    expect(result.current.isOverridden).toBe(false);
+
+    act(() => {
+      result.current.setSelectedModel('composer-2.5');
+    });
+
+    expect(result.current.isOverridden).toBe(true);
+  });
+
+  it('reads a key and its cli id as the same pick', () => {
+    const { result } = renderHook(() =>
+      useTurnRouting({
+        session: makeSession({
+          providerPreference: {
+            defaultProvider: 'anthropic',
+            defaultModel: 'opus-5',
+            allowTurnOverride: true,
+          },
+        }),
+      }),
+    );
+
+    act(() => {
+      result.current.setSelectedModel('claude-opus-5');
+    });
+
+    expect(result.current.isOverridden).toBe(false);
+  });
+
+  it('resets an agent back to the combo the reference names', () => {
+    useAppStore.setState({
+      selectedAgentId: { [SESSION_ID]: AGENT_ID },
+      sessionPhaseRuns: {
+        [SESSION_ID]: [makeScoutRow({ kind: 'implementer', providerOverride: 'cursor' })],
+      },
+      agentModelOverride: {},
+      agentProviderOverride: { [AGENT_ID]: 'cursor' },
+      agentEffortOverride: {},
+      workspaceOverrides: {
+        'ws-1': {
+          roleModels: {
+            implementer: { providerId: 'cursor', model: 'composer-2.5-fast', effort: 'medium' },
+          },
+        },
+      } as never,
+    });
+
+    const { result } = renderHook(() => useTurnRouting({ session: cursorSession() }));
+
+    expect(result.current.referenceModel).toBe('composer-2.5-fast');
+
+    act(() => {
+      result.current.onResetTurnOverride();
+    });
+
+    expect(setAgentConfig).toHaveBeenLastCalledWith(
+      SESSION_ID,
+      AGENT_ID,
+      expect.objectContaining({ modelOverride: 'composer-2.5-fast' }),
+    );
+  });
+});

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.ts
@@ -3,9 +3,11 @@ import { useShallow } from 'zustand/react/shallow';
 import type { ProviderId, Session, TurnProviderOverride } from '@goodboy/types';
 import {
   PROVIDER_CAPABILITIES,
+  canonicalModelId,
   getDefaultTurnModel,
   resolveModelForProvider,
   resolveStoredModelSelection,
+  resolvedStoredModelId,
 } from '@goodboy/core';
 import { useAppStore } from '../../../../../store';
 import { agentPinApplies } from '../../../../../store/slices/turn/agentPinApplies';
@@ -129,7 +131,7 @@ export const useTurnRouting = ({ session }: Params) => {
   const referenceEffort: EffortLevel = reference.effort;
   const effectiveProvider: ProviderId =
     selectedProvider ?? agentProviderOverride ?? defaultProvider;
-  const effectiveModelId =
+  const effectiveStoredId =
     selectedModel ??
     (agentPinApplies({
       agentModelPin: agentModelOverride,
@@ -143,13 +145,13 @@ export const useTurnRouting = ({ session }: Params) => {
       : getDefaultTurnModel({ id: effectiveProvider }));
   const effectiveModel = resolveModelForProvider({
     provider: effectiveProvider,
-    modelId: effectiveModelId,
+    modelId: effectiveStoredId,
   });
   const effectiveEffort = clampEffort(effectiveModel, effort);
   const effectiveSelection = useMemo(() => {
     const stored = resolveStoredModelSelection({
       provider: effectiveProvider,
-      id: effectiveModelId,
+      id: effectiveStoredId,
       effort: effectiveEffort,
     });
     if (stored.report?.kind !== 'unknown') {
@@ -160,7 +162,15 @@ export const useTurnRouting = ({ session }: Params) => {
       id: effectiveModel,
       effort: effectiveEffort,
     }).selection;
-  }, [effectiveProvider, effectiveModelId, effectiveModel, effectiveEffort]);
+  }, [effectiveProvider, effectiveStoredId, effectiveModel, effectiveEffort]);
+  const effectiveModelId = useMemo(
+    () => resolvedStoredModelId({ provider: effectiveProvider, selection: effectiveSelection }),
+    [effectiveProvider, effectiveSelection],
+  );
+  const isOverridden =
+    effectiveProvider !== referenceProvider ||
+    canonicalModelId({ provider: effectiveProvider, modelId: effectiveModelId }) !==
+      canonicalModelId({ provider: referenceProvider, modelId: referenceModel });
 
   const routingOverride: TurnProviderOverride | undefined = useMemo(() => {
     if (!allowOverride) {
@@ -335,7 +345,10 @@ export const useTurnRouting = ({ session }: Params) => {
     setVerbosityState,
     effectiveProvider,
     effectiveModel,
+    effectiveModelId,
+    effectiveSelection,
     effectiveEffort,
+    isOverridden,
     referenceProvider,
     referenceModel,
     referenceEffort,

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.ts
@@ -167,10 +167,19 @@ export const useTurnRouting = ({ session }: Params) => {
     () => resolvedStoredModelId({ provider: effectiveProvider, selection: effectiveSelection }),
     [effectiveProvider, effectiveSelection],
   );
+  const effectiveExecution = canonicalModelId({
+    provider: effectiveProvider,
+    modelId: effectiveModelId,
+  });
+  const referenceExecution = canonicalModelId({
+    provider: referenceProvider,
+    modelId: referenceModel,
+  });
   const isOverridden =
     effectiveProvider !== referenceProvider ||
-    canonicalModelId({ provider: effectiveProvider, modelId: effectiveModelId }) !==
-      canonicalModelId({ provider: referenceProvider, modelId: referenceModel });
+    effectiveExecution == null ||
+    referenceExecution == null ||
+    effectiveExecution !== referenceExecution;
 
   const routingOverride: TurnProviderOverride | undefined = useMemo(() => {
     if (!allowOverride) {

--- a/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
@@ -870,3 +870,112 @@ describe('ChatInput, all providers over budget', () => {
     expect(sendTurnMock).toHaveBeenCalledOnce();
   });
 });
+
+describe('ChatInput, cursor combo axes', () => {
+  const cursorSession = (defaultModel?: string): Session =>
+    makeSession({
+      providerPreference: {
+        defaultProvider: 'cursor' as Session['providerPreference']['defaultProvider'],
+        ...(defaultModel != null && { defaultModel }),
+        allowTurnOverride: true,
+      },
+    });
+
+  const togglePicker = async (user: ReturnType<typeof userEvent.setup>) =>
+    user.click(screen.getByRole('button', { name: /^Model routing:/ }));
+
+  const modeChip = (label: string) =>
+    within(
+      within(screen.getByRole('dialog', { name: 'Model routing' })).getByRole('group', {
+        name: 'Modes',
+      }),
+    ).getByRole('button', { name: label });
+
+  it('still reads Fast as on after the picker is closed and reopened', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput session={cursorSession()} />);
+
+    await togglePicker(user);
+    await user.click(modeChip('Fast'));
+    await togglePicker(user);
+    await togglePicker(user);
+
+    expect(modeChip('Fast').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('marks Fast as an override and offers the reset back to the default', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput session={cursorSession()} />);
+
+    await togglePicker(user);
+    await user.click(modeChip('Fast'));
+
+    expect(await screen.findByLabelText('Reset routing override')).toBeTruthy();
+    expect(screen.getByRole('dialog', { name: 'Model routing' }).textContent).toContain(
+      'Overriding default',
+    );
+  });
+
+  it('sends the fast combo the picker shows', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput session={cursorSession()} />);
+
+    await togglePicker(user);
+    await user.click(modeChip('Fast'));
+    await togglePicker(user);
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'go fast');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(sendTurnMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          override: expect.objectContaining({
+            providerId: 'cursor',
+            selection: expect.objectContaining({
+              key: 'composer-2.5',
+              toggles: expect.objectContaining({ fast: true }),
+            }),
+          }),
+        }),
+      );
+    });
+  });
+
+  it('reads a Fast default as the default, not as an override', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput session={cursorSession('composer-2.5-fast')} />);
+
+    expect(screen.queryByLabelText('Reset routing override')).toBeNull();
+
+    await togglePicker(user);
+    expect(modeChip('Fast').getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('dialog', { name: 'Model routing' }).textContent).toContain(
+      'Using default',
+    );
+  });
+
+  it('marks the return to base from a Fast default as an override', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput session={cursorSession('composer-2.5-fast')} />);
+
+    await togglePicker(user);
+    await user.click(modeChip('Fast'));
+
+    expect(await screen.findByLabelText('Reset routing override')).toBeTruthy();
+    expect(modeChip('Fast').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('still reads Thinking as on after the picker is closed and reopened', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput session={cursorSession('claude-4.6-sonnet-medium')} />);
+
+    await togglePicker(user);
+    await user.click(modeChip('Thinking'));
+    await togglePicker(user);
+    await togglePicker(user);
+
+    expect(modeChip('Thinking').getAttribute('aria-pressed')).toBe('true');
+  });
+});

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -148,7 +148,7 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
     isFirstTurnForAgent,
     value,
     attachments,
-    effectiveModel: routing.effectiveModel,
+    effectiveModel: routing.effectiveModelId,
     modelCandidates: routing.modelCandidates,
     allowOverride: routing.allowOverride,
   });
@@ -376,7 +376,7 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
     scopePending: scope.scopePending,
     rightSizePending: rightSize.rightSizePending,
     rightSizeSuggestion: rightSize.rightSizeSuggestion,
-    effectiveModel: routing.effectiveModel,
+    effectiveModel: routing.effectiveModelId,
     onScopeSpawn,
     onScopeSendAnyway,
     onScopeDismiss,
@@ -570,7 +570,7 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
                 ariaLabel="Model routing"
                 openEvent="goodboy:open-model-picker"
                 provider={routing.effectiveProvider}
-                model={routing.effectiveModel}
+                model={routing.effectiveModelId}
                 effort={{
                   editable: true,
                   value: routing.effectiveEffort,
@@ -580,10 +580,7 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
                 connectedProviders={routing.connectedProviderIds}
                 disabled={!routing.allowOverride}
                 disabledTitle={overrideDisabledTitle}
-                overridden={
-                  routing.effectiveProvider !== routing.referenceProvider ||
-                  routing.effectiveModel !== routing.referenceModel
-                }
+                overridden={routing.isOverridden}
                 defaultSummary={`${PROVIDER_LABEL[routing.referenceProvider]} · ${modelLabel(
                   routing.referenceModel,
                 )}`}

--- a/apps/desktop/src/features/chat/utils/chat-constants.test.ts
+++ b/apps/desktop/src/features/chat/utils/chat-constants.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { modelLabel } from './chat-constants';
+import { modelLabel, suggestHeavierModel } from './chat-constants';
 
 describe('modelLabel', () => {
   it('uses the authored Astra label for its catalog key and cli id', () => {
@@ -21,5 +21,22 @@ describe('modelLabel', () => {
 
   it('keeps the version number intact for an unknown vendor-prefixed id', () => {
     expect(modelLabel('mistral-large-2.1')).toBe('Mistral Large 2.1');
+  });
+});
+
+describe('suggestHeavierModel, price of the model actually running', () => {
+  const CURSOR_CANDIDATES = ['auto', 'composer-2.5', 'sonnet-4.6', 'opus-5', 'gpt-5.6'];
+
+  it('prices the step up from the combo that is running, not from its base', () => {
+    const fromFast = suggestHeavierModel('composer-2.5-fast', CURSOR_CANDIDATES);
+    const fromBase = suggestHeavierModel('composer-2.5', CURSOR_CANDIDATES);
+
+    expect(fromFast?.id).toBe(fromBase?.id);
+    expect(fromFast?.costMultiplier).toBeLessThan(fromBase?.costMultiplier ?? 0);
+    expect(fromFast?.costMultiplier).toBeCloseTo(1.7, 5);
+  });
+
+  it('keeps the composer suggestion strong, so the multiplier stays out of the card', () => {
+    expect(suggestHeavierModel('composer-2.5-fast', CURSOR_CANDIDATES)?.kind).toBe('strong');
   });
 });

--- a/apps/desktop/src/store/slices/turn/agentReferenceRouting.test.ts
+++ b/apps/desktop/src/store/slices/turn/agentReferenceRouting.test.ts
@@ -231,3 +231,56 @@ describe('agentReferenceRouting', () => {
     expect(withGarbage).toEqual(pristine);
   });
 });
+
+describe('agentReferenceRouting, combo axes', () => {
+  it('keeps the fast combo of the session default model', () => {
+    const result = agentReferenceRouting({
+      agent: null,
+      stepConfig: null,
+      roleModels: null,
+      session: makeSession({
+        providerPreference: {
+          defaultProvider: 'cursor',
+          defaultModel: 'composer-2.5-fast',
+          allowTurnOverride: true,
+        },
+      }),
+    });
+
+    expect(result).toEqual({ provider: 'cursor', model: 'composer-2.5-fast', effort: 'medium' });
+  });
+
+  it('keeps the thinking combo a step pins', () => {
+    const result = agentReferenceRouting({
+      agent: makeAgent({ kind: 'implementer', name: 'Build' }),
+      stepConfig: makeStep({
+        name: 'Build',
+        providerOverride: 'cursor',
+        modelOverride: 'claude-4.6-sonnet-medium-thinking',
+      }),
+      roleModels: null,
+      session: makeSession({
+        providerPreference: { defaultProvider: 'cursor', allowTurnOverride: true },
+      }),
+    });
+
+    expect(result.model).toBe('claude-4.6-sonnet-medium-thinking');
+  });
+
+  it('never reads a collapsed default back as a combo', () => {
+    const result = agentReferenceRouting({
+      agent: null,
+      stepConfig: null,
+      roleModels: null,
+      session: makeSession({
+        providerPreference: {
+          defaultProvider: 'cursor',
+          defaultModel: 'composer-2.5',
+          allowTurnOverride: true,
+        },
+      }),
+    });
+
+    expect(result.model).toBe('composer-2.5');
+  });
+});

--- a/apps/desktop/src/store/slices/turn/agentReferenceRouting.ts
+++ b/apps/desktop/src/store/slices/turn/agentReferenceRouting.ts
@@ -6,7 +6,11 @@ import type {
   Session,
   Step,
 } from '@goodboy/types';
-import { PROVIDER_CAPABILITIES, getDefaultTurnModel, resolveModelForProvider } from '@goodboy/core';
+import {
+  PROVIDER_CAPABILITIES,
+  getDefaultTurnModel,
+  resolveModelIdForProvider,
+} from '@goodboy/core';
 import { classifyAgent, type AgentKind } from '../../../features/session/agent-kind';
 import { resolveStepRouting } from '../../../features/workflows/resolveStepRouting';
 
@@ -45,7 +49,7 @@ export const agentReferenceRouting = ({
       session.providerPreference.defaultModel ?? getDefaultTurnModel({ id: provider });
     return {
       provider,
-      model: resolveModelForProvider({ provider, modelId }),
+      model: resolveModelIdForProvider({ provider, modelId }),
       effort: session.effort ?? 'medium',
     };
   }
@@ -59,7 +63,7 @@ export const agentReferenceRouting = ({
   });
   return {
     provider: routing.provider,
-    model: resolveModelForProvider({ provider: routing.provider, modelId: routing.model }),
+    model: resolveModelIdForProvider({ provider: routing.provider, modelId: routing.model }),
     effort: routing.effort,
   };
 };

--- a/apps/desktop/src/store/slices/turn/pickedTurnExecution.test.ts
+++ b/apps/desktop/src/store/slices/turn/pickedTurnExecution.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { pickedTurnExecution } from './pickedTurnExecution';
+
+describe('pickedTurnExecution', () => {
+  it('says nothing was picked when there is no override', () => {
+    expect(pickedTurnExecution({ override: undefined })).toEqual({ kind: 'unspecified' });
+  });
+
+  it('says nothing was picked when the override names only a provider', () => {
+    expect(pickedTurnExecution({ override: { providerId: 'cursor' } })).toEqual({
+      kind: 'unspecified',
+    });
+  });
+
+  it('resolves a key to the execution it names', () => {
+    expect(
+      pickedTurnExecution({ override: { providerId: 'cursor', model: 'composer-2.5' } }),
+    ).toEqual({ kind: 'resolved', id: 'composer-2.5' });
+  });
+
+  it('keeps the combo the selection carries', () => {
+    expect(
+      pickedTurnExecution({
+        override: {
+          providerId: 'cursor',
+          model: 'composer-2.5',
+          selection: { key: 'composer-2.5', toggles: { thinking: false, fast: true } },
+        },
+      }),
+    ).toEqual({ kind: 'resolved', id: 'composer-2.5-fast' });
+  });
+
+  it('reads a key and its cli id as the same execution', () => {
+    expect(
+      pickedTurnExecution({ override: { providerId: 'anthropic', model: 'claude-opus-5' } }),
+    ).toEqual(pickedTurnExecution({ override: { providerId: 'anthropic', model: 'opus-5' } }));
+  });
+
+  it('refuses to resolve a model no provider offers', () => {
+    expect(
+      pickedTurnExecution({ override: { providerId: 'cursor', model: 'not-a-model' } }),
+    ).toEqual({ kind: 'unresolved', id: 'not-a-model' });
+  });
+
+  it('refuses to resolve a selection whose key no provider offers', () => {
+    expect(
+      pickedTurnExecution({
+        override: {
+          providerId: 'cursor',
+          model: 'not-a-model',
+          selection: { key: 'not-a-model' },
+        },
+      }),
+    ).toEqual({ kind: 'unresolved', id: 'not-a-model' });
+  });
+});

--- a/apps/desktop/src/store/slices/turn/pickedTurnExecution.ts
+++ b/apps/desktop/src/store/slices/turn/pickedTurnExecution.ts
@@ -1,0 +1,33 @@
+import { canonicalModelId, modelIdForSelection } from '@goodboy/core';
+import type { TurnProviderOverride } from '@goodboy/types';
+
+export type PickedTurnExecution =
+  | { readonly kind: 'unspecified' }
+  | { readonly kind: 'unresolved'; readonly id: string }
+  | { readonly kind: 'resolved'; readonly id: string };
+
+type Params = {
+  readonly override: TurnProviderOverride | undefined;
+};
+
+export const pickedTurnExecution = ({ override }: Params): PickedTurnExecution => {
+  if (override == null) {
+    return { kind: 'unspecified' };
+  }
+  const provider = override.providerId;
+  const selection = override.selection;
+  if (selection != null) {
+    if (canonicalModelId({ provider, modelId: selection.key }) == null) {
+      return { kind: 'unresolved', id: override.model ?? selection.key };
+    }
+    return { kind: 'resolved', id: modelIdForSelection({ provider, selection }) };
+  }
+  if (override.model == null) {
+    return { kind: 'unspecified' };
+  }
+  const canonical = canonicalModelId({ provider, modelId: override.model });
+  if (canonical == null) {
+    return { kind: 'unresolved', id: override.model };
+  }
+  return { kind: 'resolved', id: canonical };
+};

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -4,8 +4,10 @@ import {
   buildChainCarryForward,
   autoPopulateContext,
   buildStepPrompt,
+  canonicalModelId,
   findReusableAgent,
   isFallbackStepOutputSummary,
+  modelIdForSelection,
   planTurnFallback,
   resolveModelArgs,
   resolveRoleRouting,
@@ -491,16 +493,30 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
       throw new Error(`resolved model args omit ${modelFlag} for ${provider}`);
     }
     const model = spawnModel;
+    const pickedModel =
+      pickedOverride == null
+        ? null
+        : pickedOverride.selection != null
+          ? modelIdForSelection({
+              provider: pickedOverride.providerId,
+              selection: pickedOverride.selection,
+            })
+          : pickedOverride.model != null
+            ? canonicalModelId({
+                provider: pickedOverride.providerId,
+                modelId: pickedOverride.model,
+              })
+            : null;
     if (
       pickedOverride != null &&
       (provider !== pickedOverride.providerId ||
-        (pickedOverride.model != null && modelSelection.key !== pickedOverride.model))
+        (pickedModel != null && pickedModel !== spawnModel))
     ) {
       void get().emitNotification(
         'error',
         'warning',
         'the turn did not run on the model you picked',
-        `you picked ${pickedOverride.providerId}/${pickedOverride.model ?? modelSelection.key}, the turn ran on ${provider}/${modelSelection.key}`,
+        `you picked ${pickedOverride.providerId}/${pickedModel ?? spawnModel}, the turn ran on ${provider}/${spawnModel}`,
         { sessionId },
       );
     }
@@ -1268,7 +1284,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         : planTurnFallback({
             failure: failure.kind,
             provider,
-            model: modelSelection.key,
+            model: spawnModel,
             connectedProviders,
             attempt: retry?.attempt ?? 0,
             ...(preferredFallback != null && {
@@ -1355,7 +1371,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
               retry: {
                 attempt: 0,
                 provider,
-                model: modelSelection.key,
+                model: spawnModel,
                 attachmentRefs,
               },
             }).catch(() => undefined);

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -4,10 +4,8 @@ import {
   buildChainCarryForward,
   autoPopulateContext,
   buildStepPrompt,
-  canonicalModelId,
   findReusableAgent,
   isFallbackStepOutputSummary,
-  modelIdForSelection,
   planTurnFallback,
   resolveModelArgs,
   resolveRoleRouting,
@@ -128,6 +126,7 @@ import { completeResolvedAgent } from './completeResolvedAgent';
 import { resolvePhaseAgent } from './resolvePhaseAgent';
 import { resolveSkillPrompt } from './resolveSkillPrompt';
 import { persistAttachments } from './persistAttachments';
+import { pickedTurnExecution } from './pickedTurnExecution';
 import { auditToolCall } from './auditToolCall';
 import { resolveErrorTurnMessage } from './resolveErrorTurnMessage';
 import { fallbackNoticeMessage } from './fallbackNoticeMessage';
@@ -493,30 +492,17 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
       throw new Error(`resolved model args omit ${modelFlag} for ${provider}`);
     }
     const model = spawnModel;
-    const pickedModel =
-      pickedOverride == null
-        ? null
-        : pickedOverride.selection != null
-          ? modelIdForSelection({
-              provider: pickedOverride.providerId,
-              selection: pickedOverride.selection,
-            })
-          : pickedOverride.model != null
-            ? canonicalModelId({
-                provider: pickedOverride.providerId,
-                modelId: pickedOverride.model,
-              })
-            : null;
+    const picked = pickedTurnExecution({ override: pickedOverride });
+    const ranAsPicked = picked.kind === 'unspecified' || picked.id === spawnModel;
     if (
       pickedOverride != null &&
-      (provider !== pickedOverride.providerId ||
-        (pickedModel != null && pickedModel !== spawnModel))
+      (provider !== pickedOverride.providerId || picked.kind === 'unresolved' || !ranAsPicked)
     ) {
       void get().emitNotification(
         'error',
         'warning',
         'the turn did not run on the model you picked',
-        `you picked ${pickedOverride.providerId}/${pickedModel ?? spawnModel}, the turn ran on ${provider}/${spawnModel}`,
+        `you picked ${pickedOverride.providerId}/${picked.kind === 'unspecified' ? spawnModel : picked.id}, the turn ran on ${provider}/${spawnModel}`,
         { sessionId },
       );
     }

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -665,6 +665,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
       } catch {}
       if (decision.action === 'next') {
         const enforced = enforceOrchestratorModelPool({
+          provider: defaultProvider,
           step: decision.step,
           pool: modelMenu,
           roleDefaults,

--- a/apps/desktop/src/store/slices/workflows/preSpawnWorkflowAgents.test.ts
+++ b/apps/desktop/src/store/slices/workflows/preSpawnWorkflowAgents.test.ts
@@ -1,10 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ROLE_DEFAULTS } from '@goodboy/core';
+import {
+  ROLE_DEFAULTS,
+  getCheapModel,
+  resolveModelArgs,
+  resolveModelForProvider,
+  resolveStoredModelSelection,
+} from '@goodboy/core';
 import type {
   Agent,
   AgentId,
   IsoDateTime,
   ProviderId,
+  ModelEffort,
   RoleModelPreferences,
   Session,
   SessionId,
@@ -206,7 +213,7 @@ describe('preSpawnWorkflowAgents and agentReferenceRouting agree', () => {
       roleModels,
     });
 
-    expect(persisted.provider).toBe('anthropic');
+    expect(persisted).toEqual({ provider: 'anthropic', model: 'sonnet-5', effort: 'high' });
     expect(reference).toEqual(persisted);
   });
 
@@ -217,7 +224,11 @@ describe('preSpawnWorkflowAgents and agentReferenceRouting agree', () => {
       roleModels: null,
     });
 
-    expect(persisted.provider).toBe('codex');
+    expect(persisted).toEqual({
+      provider: 'codex',
+      model: resolveModelForProvider({ provider: 'codex', modelId: getCheapModel('codex') }),
+      effort: 'low',
+    });
     expect(reference).toEqual(persisted);
   });
 
@@ -238,5 +249,91 @@ describe('preSpawnWorkflowAgents and agentReferenceRouting agree', () => {
 
     expect(persisted).toEqual({ provider: 'anthropic', model: 'opus-5', effort: 'high' });
     expect(reference).toEqual(persisted);
+  });
+});
+
+const executionOf = ({
+  provider,
+  model,
+  effort,
+}: {
+  readonly provider: ProviderId;
+  readonly model: string;
+  readonly effort: ModelEffort | undefined;
+}): ReadonlyArray<string> =>
+  resolveModelArgs({
+    provider,
+    selection: resolveStoredModelSelection({
+      provider,
+      id: model,
+      ...(effort != null && { effort }),
+    }).selection,
+  }).args;
+
+describe('preSpawnWorkflowAgents keeps the combo a step pinned', () => {
+  it('persists the cursor fast combo and runs it', async () => {
+    const { persisted, reference } = await spawnAndReference({
+      spawnStep: step({
+        role: 'implementer',
+        providerOverride: 'cursor',
+        modelOverride: 'composer-2.5-fast',
+      }),
+      defaultProvider: 'cursor',
+      roleModels: null,
+    });
+
+    expect(persisted.model).toBe('composer-2.5-fast');
+    expect(reference).toEqual(persisted);
+    expect(
+      executionOf({
+        provider: 'cursor',
+        model: persisted.model ?? '',
+        effort: persisted.effort,
+      }),
+    ).toContain('composer-2.5-fast');
+  });
+
+  it('persists the cursor thinking combo and runs it', async () => {
+    const { persisted, reference } = await spawnAndReference({
+      spawnStep: step({
+        role: 'implementer',
+        providerOverride: 'cursor',
+        modelOverride: 'claude-4.6-sonnet-medium-thinking',
+      }),
+      defaultProvider: 'cursor',
+      roleModels: null,
+    });
+
+    expect(persisted.model).toBe('claude-4.6-sonnet-medium-thinking');
+    expect(reference).toEqual(persisted);
+    expect(
+      executionOf({
+        provider: 'cursor',
+        model: persisted.model ?? '',
+        effort: persisted.effort,
+      }),
+    ).toContain('claude-4.6-sonnet-medium-thinking');
+  });
+
+  it('leaves a base pin alone on both sides', async () => {
+    const { persisted, reference } = await spawnAndReference({
+      spawnStep: step({
+        role: 'implementer',
+        providerOverride: 'cursor',
+        modelOverride: 'composer-2.5',
+      }),
+      defaultProvider: 'cursor',
+      roleModels: null,
+    });
+
+    expect(persisted.model).toBe('composer-2.5');
+    expect(reference).toEqual(persisted);
+    expect(
+      executionOf({
+        provider: 'cursor',
+        model: persisted.model ?? '',
+        effort: persisted.effort,
+      }),
+    ).toContain('composer-2.5');
   });
 });

--- a/apps/desktop/src/store/slices/workflows/preSpawnWorkflowAgents.ts
+++ b/apps/desktop/src/store/slices/workflows/preSpawnWorkflowAgents.ts
@@ -8,7 +8,7 @@ import type {
   VerbosityLevel,
   WorkflowRunId,
 } from '@goodboy/types';
-import { resolveModelForProvider } from '@goodboy/core';
+import { resolveModelIdForProvider } from '@goodboy/core';
 import { ROLE_TO_KIND, inferAgentKindFromName } from '../../../features/session/agent-kind';
 import { resolveStepRouting } from '../../../features/workflows/resolveStepRouting';
 import { invokeAgentInsert } from '../../../features/workflows/workflows';
@@ -59,7 +59,7 @@ export const preSpawnWorkflowAgents = async ({
       sessionEffort: sessionEffort ?? null,
     });
     const provider = routing.provider;
-    const model = resolveModelForProvider({ provider, modelId: routing.model });
+    const model = resolveModelIdForProvider({ provider, modelId: routing.model });
     const agent = await invokeAgentInsert({
       sessionId,
       stepId: step.id,

--- a/apps/desktop/src/store/store.turn-combo-identity.test.ts
+++ b/apps/desktop/src/store/store.turn-combo-identity.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  AgentId,
+  IsoDateTime,
+  ProjectId,
+  SessionId,
+  TurnProviderOverride,
+  WorkspaceId,
+} from '@goodboy/types';
+import {
+  buildStoryAgent,
+  buildStorySession,
+  buildStoryWorkspace,
+  emptyTurnStream,
+  resetStorySpies,
+  storySpies,
+} from './storyHarness';
+
+vi.mock('@tauri-apps/api/core', async () => (await import('./storyHarness')).tauriCoreModuleMock());
+vi.mock('@tauri-apps/api/event', async () =>
+  (await import('./storyHarness')).tauriEventModuleMock(),
+);
+vi.mock('../shared/lib/db', async () => (await import('./storyHarness')).dbLibModuleMock());
+vi.mock('@goodboy/db', async () => (await import('./storyHarness')).dbModuleMock());
+vi.mock('../features/chat/turn', async () => (await import('./storyHarness')).turnModuleMock());
+vi.mock('../features/permissions/permissions', async () =>
+  (await import('./storyHarness')).permissionsModuleMock(),
+);
+vi.mock('../features/providers/providers', async () =>
+  (await import('./storyHarness')).providersModuleMock(),
+);
+vi.mock('../features/providers/routing', async () =>
+  (await import('./storyHarness')).routingModuleMock(),
+);
+vi.mock('../features/budget/budget', async () =>
+  (await import('./storyHarness')).budgetModuleMock(),
+);
+vi.mock('../features/skills/skills', async () =>
+  (await import('./storyHarness')).skillsModuleMock(),
+);
+vi.mock('../features/workflows/workflows', async () =>
+  (await import('./storyHarness')).workflowsModuleMock(),
+);
+vi.mock('../features/worktree/worktree', async () =>
+  (await import('./storyHarness')).worktreeModuleMock(),
+);
+vi.mock('../shared/lib/repo', async () => (await import('./storyHarness')).repoModuleMock());
+vi.mock('../features/plans/plans', async () => (await import('./storyHarness')).plansModuleMock());
+
+const SESSION_ID = 'session-combo-1' as SessionId;
+const AGENT_A = 'agent-combo-a' as AgentId;
+const WORKSPACE_ID = 'workspace-combo' as WorkspaceId;
+const NOW = '2026-07-30T00:00:00.000Z' as IsoDateTime;
+const USAGE_LIMIT_MESSAGE = "You've hit your usage limit. Try again at 3:10 PM.";
+
+const FAST_OVERRIDE: TurnProviderOverride = {
+  providerId: 'cursor',
+  model: 'composer-2.5',
+  selection: { key: 'composer-2.5', toggles: { thinking: false, fast: true } },
+  explicit: true,
+};
+
+const connectedCursorState = () => ({
+  providers: [
+    {
+      id: 'cursor',
+      binary: 'cursor-agent',
+      connection: 'connected',
+      name: 'Cursor',
+      installation: 'installed',
+    } as never,
+  ],
+  authResults: { cursor: { state: 'connected', identity: 'test' } } as never,
+});
+
+type StoreModule = typeof import('./store');
+let useAppStore: StoreModule['useAppStore'];
+
+beforeAll(async () => {
+  ({ useAppStore } = await import('./store'));
+}, 60_000);
+
+const mockRouting = async (fallbackUsed: boolean) => {
+  const routingMod = await import('../features/providers/routing');
+  (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
+    selectedProvider: 'cursor',
+    selectedModel: 'composer-2.5',
+    reason: 'preference',
+    fallbackUsed,
+  });
+};
+
+describe('sendTurn keeps the executed combo across a retry', () => {
+  beforeEach(async () => {
+    resetStorySpies();
+    storySpies.runTurn.mockImplementation(() => emptyTurnStream());
+    storySpies.tauriInvoke.mockResolvedValue({
+      stdout: JSON.stringify({ result: JSON.stringify({ upserts: [] }) }),
+      stderr: '',
+      exitCode: 0,
+    } as never);
+    await mockRouting(false);
+  });
+
+  afterEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  const setup = () => {
+    useAppStore.setState({
+      sessions: [
+        buildStorySession({
+          id: SESSION_ID,
+          workspaceId: WORKSPACE_ID,
+          goal: 'test combo identity',
+          state: { kind: 'idle', lastActivityAt: NOW },
+          providerPreference: { defaultProvider: 'cursor', allowTurnOverride: true },
+        }),
+      ],
+      projects: [],
+      sessionWorktrees: { [SESSION_ID]: ['/tmp/wt'] },
+      sessionProjectMounts: {
+        [SESSION_ID]: [
+          {
+            projectId: 'project-combo' as ProjectId,
+            mountName: 'repo',
+            worktreePath: '/tmp/wt',
+            repoRoot: '/tmp/repo',
+            branch: 'goodboy/combo',
+          },
+        ],
+      },
+      sessionPhaseRuns: {
+        [SESSION_ID]: [buildStoryAgent({ id: AGENT_A, sessionId: SESSION_ID, name: 'agent 0' })],
+      },
+      selectedAgentId: { [SESSION_ID]: AGENT_A },
+      transcripts: { [AGENT_A]: [] },
+      agentEffortOverride: {},
+      agentProviderOverride: {},
+      agentModelOverride: {},
+      providerCooldowns: {},
+      notifications: [],
+      workspaces: [
+        buildStoryWorkspace({ id: WORKSPACE_ID, name: 'ws', slug: 'ws', sessionsRoot: '/tmp' }),
+      ],
+      ...connectedCursorState(),
+    });
+  };
+
+  const spawnedModels = (): ReadonlyArray<string | undefined> =>
+    storySpies.runTurn.mock.calls.map((call) => call[0]?.model);
+
+  it('repeats the fast combo when the provider is unreachable', async () => {
+    setup();
+    storySpies.runTurn.mockImplementationOnce(async function* () {
+      throw new Error('connect ECONNREFUSED 127.0.0.1:443');
+    });
+
+    await useAppStore.getState().sendTurn({
+      sessionId: SESSION_ID,
+      agentId: AGENT_A,
+      content: 'go',
+      override: FAST_OVERRIDE,
+    });
+
+    expect(storySpies.runTurn).toHaveBeenCalledTimes(2);
+    expect(spawnedModels()).toEqual(['composer-2.5-fast', 'composer-2.5-fast']);
+  });
+
+  it('repeats the fast combo when the usage limit retry fires', async () => {
+    setup();
+    const scheduled: Array<() => void> = [];
+    const timerSpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((
+      handler: () => void,
+    ) => {
+      scheduled.push(handler);
+      return 0;
+    }) as never);
+    storySpies.runTurn.mockImplementationOnce(async function* () {
+      throw new Error(USAGE_LIMIT_MESSAGE);
+    });
+
+    await expect(
+      useAppStore.getState().sendTurn({
+        sessionId: SESSION_ID,
+        agentId: AGENT_A,
+        content: 'go',
+        override: FAST_OVERRIDE,
+      }),
+    ).rejects.toThrow('usage limit');
+    timerSpy.mockRestore();
+
+    expect(scheduled).toHaveLength(1);
+    scheduled[0]?.();
+    await vi.waitFor(() => {
+      expect(storySpies.runTurn).toHaveBeenCalledTimes(2);
+    });
+    expect(spawnedModels()[1]).toBe('composer-2.5-fast');
+  });
+
+  it('keeps the effort of the retried turn out of the model id', async () => {
+    setup();
+    storySpies.runTurn.mockImplementationOnce(async function* () {
+      throw new Error('connect ECONNREFUSED 127.0.0.1:443');
+    });
+
+    await useAppStore.getState().sendTurn({
+      sessionId: SESSION_ID,
+      agentId: AGENT_A,
+      content: 'go',
+      override: {
+        providerId: 'cursor',
+        model: 'opus-5',
+        selection: { key: 'opus-5', effort: 'high', toggles: { thinking: true, fast: false } },
+        explicit: true,
+      },
+    });
+
+    expect(spawnedModels()).toEqual(['claude-opus-5-thinking-high', 'claude-opus-5-thinking-high']);
+  });
+});
+
+describe('sendTurn checks the model it ran against the model that was picked', () => {
+  beforeEach(async () => {
+    resetStorySpies();
+    storySpies.runTurn.mockImplementation(() => emptyTurnStream());
+    storySpies.tauriInvoke.mockResolvedValue({
+      stdout: JSON.stringify({ result: JSON.stringify({ upserts: [] }) }),
+      stderr: '',
+      exitCode: 0,
+    } as never);
+    await mockRouting(false);
+  });
+
+  afterEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  const setup = () => {
+    useAppStore.setState({
+      sessions: [
+        buildStorySession({
+          id: SESSION_ID,
+          workspaceId: WORKSPACE_ID,
+          goal: 'test combo identity',
+          state: { kind: 'idle', lastActivityAt: NOW },
+          providerPreference: { defaultProvider: 'cursor', allowTurnOverride: true },
+        }),
+      ],
+      projects: [],
+      sessionWorktrees: { [SESSION_ID]: ['/tmp/wt'] },
+      sessionProjectMounts: {
+        [SESSION_ID]: [
+          {
+            projectId: 'project-combo' as ProjectId,
+            mountName: 'repo',
+            worktreePath: '/tmp/wt',
+            repoRoot: '/tmp/repo',
+            branch: 'goodboy/combo',
+          },
+        ],
+      },
+      sessionPhaseRuns: {
+        [SESSION_ID]: [buildStoryAgent({ id: AGENT_A, sessionId: SESSION_ID, name: 'agent 0' })],
+      },
+      selectedAgentId: { [SESSION_ID]: AGENT_A },
+      transcripts: { [AGENT_A]: [] },
+      agentEffortOverride: {},
+      agentProviderOverride: {},
+      agentModelOverride: {},
+      providerCooldowns: {},
+      notifications: [],
+      workspaces: [
+        buildStoryWorkspace({ id: WORKSPACE_ID, name: 'ws', slug: 'ws', sessionsRoot: '/tmp' }),
+      ],
+      ...connectedCursorState(),
+    });
+  };
+
+  const mismatchWarning = () =>
+    useAppStore
+      .getState()
+      .notifications.find(
+        (entry) => entry.title === 'the turn did not run on the model you picked',
+      );
+
+  it('stays quiet when the pick names the combo by its slug', async () => {
+    setup();
+
+    await useAppStore.getState().sendTurn({
+      sessionId: SESSION_ID,
+      agentId: AGENT_A,
+      content: 'go',
+      override: {
+        providerId: 'cursor',
+        model: 'composer-2.5-fast',
+        selection: { key: 'composer-2.5', toggles: { thinking: false, fast: true } },
+        explicit: true,
+      },
+    });
+
+    expect(storySpies.runTurn.mock.calls[0]?.[0]?.model).toBe('composer-2.5-fast');
+    expect(mismatchWarning()).toBeUndefined();
+  });
+
+  it('stays quiet when the pick names the model by its key', async () => {
+    setup();
+
+    await useAppStore.getState().sendTurn({
+      sessionId: SESSION_ID,
+      agentId: AGENT_A,
+      content: 'go',
+      override: FAST_OVERRIDE,
+    });
+
+    expect(mismatchWarning()).toBeUndefined();
+  });
+
+  it('speaks up when the base model runs instead of the fast combo that was picked', async () => {
+    setup();
+    await mockRouting(true);
+
+    await useAppStore.getState().sendTurn({
+      sessionId: SESSION_ID,
+      agentId: AGENT_A,
+      content: 'go',
+      override: FAST_OVERRIDE,
+    });
+
+    expect(storySpies.runTurn.mock.calls[0]?.[0]?.model).toBe('composer-2.5');
+    expect(mismatchWarning()?.body).toContain('composer-2.5-fast');
+  });
+});

--- a/apps/desktop/src/store/store.turn-combo-identity.test.ts
+++ b/apps/desktop/src/store/store.turn-combo-identity.test.ts
@@ -316,6 +316,38 @@ describe('sendTurn checks the model it ran against the model that was picked', (
     expect(mismatchWarning()).toBeUndefined();
   });
 
+  it('speaks up when the picked model is one no provider offers', async () => {
+    setup();
+
+    await useAppStore.getState().sendTurn({
+      sessionId: SESSION_ID,
+      agentId: AGENT_A,
+      content: 'go',
+      override: { providerId: 'cursor', model: 'not-a-model', explicit: true },
+    });
+
+    expect(storySpies.runTurn.mock.calls[0]?.[0]?.model).toBe('composer-2.5');
+    expect(mismatchWarning()?.body).toContain('not-a-model');
+  });
+
+  it('speaks up when the picked selection names a key no provider offers', async () => {
+    setup();
+
+    await useAppStore.getState().sendTurn({
+      sessionId: SESSION_ID,
+      agentId: AGENT_A,
+      content: 'go',
+      override: {
+        providerId: 'cursor',
+        model: 'not-a-model',
+        selection: { key: 'not-a-model' },
+        explicit: true,
+      },
+    });
+
+    expect(mismatchWarning()?.body).toContain('not-a-model');
+  });
+
   it('speaks up when the base model runs instead of the fast combo that was picked', async () => {
     setup();
     await mockRouting(true);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -124,6 +124,8 @@ export {
 } from './providers/auto-model';
 
 export { resolveModelForProvider } from './providers/model-map';
+export { resolveModelIdForProvider } from './providers/resolveModelIdForProvider';
+export { canonicalModelId } from './providers/canonicalModelId';
 export { MODEL_CATALOGS } from './providers/catalogs';
 export { ANTHROPIC_CATALOG } from './providers/claude/catalog';
 export { CODEX_CATALOG } from './providers/codex/catalog';
@@ -139,6 +141,7 @@ export { resolveCursorCombo } from './providers/cursorCombo';
 export { modelAxes } from './providers/modelAxes';
 export { resolveModelArgs } from './providers/resolveModelArgs';
 export { resolveStoredModelSelection } from './providers/resolveStoredModelSelection';
+export { resolvedStoredModelId } from './providers/resolvedStoredModelId';
 export { selectionRequiresMaxMode } from './providers/selectionRequiresMaxMode';
 export type {
   EffortAxis,

--- a/packages/core/src/orchestrator/enforceOrchestratorModelPool.test.ts
+++ b/packages/core/src/orchestrator/enforceOrchestratorModelPool.test.ts
@@ -149,3 +149,29 @@ describe('enforceOrchestratorModelPool, ids that carry combo axes', () => {
     expect(result.rejection?.requested).toBe('gpt-5.6-luna');
   });
 });
+
+describe('enforceOrchestratorModelPool, ids nobody can resolve', () => {
+  it('refuses a model no provider offers', () => {
+    const result = enforceOrchestratorModelPool({
+      provider: 'anthropic',
+      step: step({ model: 'not-a-model' }),
+      pool,
+      roleDefaults,
+    });
+
+    expect(result.step.model).toBe('sonnet-5');
+    expect(result.rejection?.requested).toBe('not-a-model');
+  });
+
+  it('does not let an unresolvable pool entry stand in for the provider default', () => {
+    const result = enforceOrchestratorModelPool({
+      provider: 'anthropic',
+      step: step({ model: 'opus-5' }),
+      pool: [{ id: 'not-a-model', label: 'not a model', note: 'balanced default' }],
+      roleDefaults,
+    });
+
+    expect(result.step.model).toBe('sonnet-5');
+    expect(result.rejection?.requested).toBe('opus-5');
+  });
+});

--- a/packages/core/src/orchestrator/enforceOrchestratorModelPool.test.ts
+++ b/packages/core/src/orchestrator/enforceOrchestratorModelPool.test.ts
@@ -24,6 +24,7 @@ const step = (overrides: Partial<OrchestratorStep> = {}): OrchestratorStep => ({
 describe('enforceOrchestratorModelPool', () => {
   it('rejects a model outside the pool and falls back to the role default', () => {
     const result = enforceOrchestratorModelPool({
+      provider: 'anthropic',
       step: step({ model: 'fable-5', effort: 'max' }),
       pool,
       roleDefaults,
@@ -36,6 +37,7 @@ describe('enforceOrchestratorModelPool', () => {
 
   it('says out loud which pick it refused and what runs instead', () => {
     const result = enforceOrchestratorModelPool({
+      provider: 'anthropic',
       step: step({ model: 'fable-5' }),
       pool,
       roleDefaults,
@@ -49,7 +51,12 @@ describe('enforceOrchestratorModelPool', () => {
   it('lets a deliberate deviation inside the pool through untouched', () => {
     const deviation = step({ model: 'opus-5', effort: 'high' });
 
-    const result = enforceOrchestratorModelPool({ step: deviation, pool, roleDefaults });
+    const result = enforceOrchestratorModelPool({
+      provider: 'anthropic',
+      step: deviation,
+      pool,
+      roleDefaults,
+    });
 
     expect(result.step).toBe(deviation);
     expect(result.rejection).toBeNull();
@@ -58,7 +65,12 @@ describe('enforceOrchestratorModelPool', () => {
   it('leaves a step that accepts the role default alone', () => {
     const accepted = step();
 
-    const result = enforceOrchestratorModelPool({ step: accepted, pool, roleDefaults });
+    const result = enforceOrchestratorModelPool({
+      provider: 'anthropic',
+      step: accepted,
+      pool,
+      roleDefaults,
+    });
 
     expect(result.step).toBe(accepted);
     expect(result.rejection).toBeNull();
@@ -66,6 +78,7 @@ describe('enforceOrchestratorModelPool', () => {
 
   it('falls back to the built-in role default when the workspace configures none', () => {
     const result = enforceOrchestratorModelPool({
+      provider: 'anthropic',
       step: step({ role: 'tester', model: 'fable-5' }),
       pool,
       roleDefaults,
@@ -73,5 +86,66 @@ describe('enforceOrchestratorModelPool', () => {
 
     expect(result.step.model).toBe(ROLE_DEFAULTS.tester.model);
     expect(result.step.effort).toBe(ROLE_DEFAULTS.tester.effort);
+  });
+});
+
+describe('enforceOrchestratorModelPool, ids that carry combo axes', () => {
+  const cursorRoleDefaults: ReadonlyArray<OrchestratorRoleDefault> = [
+    { role: 'implementer', model: 'composer-2.5-fast', effort: 'medium' },
+  ];
+  const cursorPool: ReadonlyArray<OrchestratorModelOption> = [
+    { id: 'composer-2.5-fast', label: 'Composer 2.5', note: 'balanced default' },
+  ];
+
+  it('lets the configured combo through', () => {
+    const deviation = step({ model: 'composer-2.5-fast' });
+
+    const result = enforceOrchestratorModelPool({
+      provider: 'cursor',
+      step: deviation,
+      pool: cursorPool,
+      roleDefaults: cursorRoleDefaults,
+    });
+
+    expect(result.step).toBe(deviation);
+    expect(result.rejection).toBeNull();
+  });
+
+  it('refuses a combo the pool never offered', () => {
+    const result = enforceOrchestratorModelPool({
+      provider: 'cursor',
+      step: step({ model: 'composer-2.5-fast' }),
+      pool: [{ id: 'composer-2.5', label: 'Composer 2.5', note: 'balanced default' }],
+      roleDefaults: [{ role: 'implementer', model: 'composer-2.5', effort: 'medium' }],
+    });
+
+    expect(result.step.model).toBe('composer-2.5');
+    expect(result.rejection?.requested).toBe('composer-2.5-fast');
+  });
+
+  it('reads a codex key and its cli id as the same pool entry', () => {
+    const requested = step({ model: 'gpt-6-astra' });
+
+    const result = enforceOrchestratorModelPool({
+      provider: 'codex',
+      step: requested,
+      pool: [{ id: 'gpt-6', label: 'Astra', note: 'deepest reasoning' }],
+      roleDefaults: [{ role: 'implementer', model: 'gpt-6', effort: 'medium' }],
+    });
+
+    expect(result.step).toBe(requested);
+    expect(result.rejection).toBeNull();
+  });
+
+  it('keeps sol, terra and luna apart', () => {
+    const result = enforceOrchestratorModelPool({
+      provider: 'codex',
+      step: step({ model: 'gpt-5.6-luna' }),
+      pool: [{ id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', note: 'deepest reasoning' }],
+      roleDefaults: [{ role: 'implementer', model: 'gpt-5.6-sol', effort: 'medium' }],
+    });
+
+    expect(result.step.model).toBe('gpt-5.6-sol');
+    expect(result.rejection?.requested).toBe('gpt-5.6-luna');
   });
 });

--- a/packages/core/src/orchestrator/enforceOrchestratorModelPool.ts
+++ b/packages/core/src/orchestrator/enforceOrchestratorModelPool.ts
@@ -33,11 +33,15 @@ export const enforceOrchestratorModelPool = ({
     return { step, rejection: null };
   }
   const requestedExecution = canonicalModelId({ provider, modelId: requested });
-  const isAllowed = pool.some(
-    (option) =>
-      option.id === requested ||
-      canonicalModelId({ provider, modelId: option.id }) === requestedExecution,
-  );
+  const isAllowed = pool.some((option) => {
+    if (option.id === requested) {
+      return true;
+    }
+    if (requestedExecution == null) {
+      return false;
+    }
+    return canonicalModelId({ provider, modelId: option.id }) === requestedExecution;
+  });
   if (isAllowed) {
     return { step, rejection: null };
   }

--- a/packages/core/src/orchestrator/enforceOrchestratorModelPool.ts
+++ b/packages/core/src/orchestrator/enforceOrchestratorModelPool.ts
@@ -1,4 +1,5 @@
-import type { ModelEffort } from '@goodboy/types';
+import type { ModelEffort, ProviderId } from '@goodboy/types';
+import { canonicalModelId } from '../providers/canonicalModelId';
 import { defaultsForRole } from '../roles';
 import type { OrchestratorModelOption, OrchestratorRoleDefault, OrchestratorStep } from './types';
 
@@ -15,12 +16,14 @@ export type EnforcedOrchestratorStep = {
 };
 
 type Params = {
+  readonly provider: ProviderId;
   readonly step: OrchestratorStep;
   readonly pool: ReadonlyArray<OrchestratorModelOption>;
   readonly roleDefaults: ReadonlyArray<OrchestratorRoleDefault>;
 };
 
 export const enforceOrchestratorModelPool = ({
+  provider,
   step,
   pool,
   roleDefaults,
@@ -29,7 +32,13 @@ export const enforceOrchestratorModelPool = ({
   if (requested == null) {
     return { step, rejection: null };
   }
-  if (pool.some((option) => option.id === requested)) {
+  const requestedExecution = canonicalModelId({ provider, modelId: requested });
+  const isAllowed = pool.some(
+    (option) =>
+      option.id === requested ||
+      canonicalModelId({ provider, modelId: option.id }) === requestedExecution,
+  );
+  if (isAllowed) {
     return { step, rejection: null };
   }
   const configured = roleDefaults.find((entry) => entry.role === step.role);

--- a/packages/core/src/orchestrator/parser.test.ts
+++ b/packages/core/src/orchestrator/parser.test.ts
@@ -207,3 +207,60 @@ describe('parseOrchestratorDecision', () => {
     expect(empty).not.toHaveProperty('runSummary');
   });
 });
+
+describe('parseOrchestratorDecision, combo axes', () => {
+  it('keeps the cursor fast combo the orchestrator asked for', () => {
+    expect(
+      parseOrchestratorDecision({
+        raw: '<<orchestrator>>{"action":"next","reason":"x","step":{"name":"Fix","role":"implementer","promptPrefix":"Fix it.","model":"composer-2.5-fast"}}<</orchestrator>>',
+        provider: 'cursor',
+      }),
+    ).toEqual({
+      action: 'next',
+      reason: 'x',
+      step: {
+        name: 'Fix',
+        role: 'implementer',
+        promptPrefix: 'Fix it.',
+        model: 'composer-2.5-fast',
+      },
+    });
+  });
+
+  it('keeps the cursor thinking combo the orchestrator asked for', () => {
+    const decision = parseOrchestratorDecision({
+      raw: '<<orchestrator>>{"action":"next","reason":"x","step":{"name":"Plan","role":"planner","promptPrefix":"Plan it.","model":"claude-4.6-sonnet-medium-thinking"}}<</orchestrator>>',
+      provider: 'cursor',
+    });
+
+    expect(decision?.action === 'next' && decision.step.model).toBe(
+      'claude-4.6-sonnet-medium-thinking',
+    );
+  });
+
+  it('leaves a plain key alone', () => {
+    const decision = parseOrchestratorDecision({
+      raw: '<<orchestrator>>{"action":"next","reason":"x","step":{"name":"Fix","role":"implementer","promptPrefix":"Fix it.","model":"composer-2.5"}}<</orchestrator>>',
+      provider: 'cursor',
+    });
+
+    expect(decision?.action === 'next' && decision.step.model).toBe('composer-2.5');
+  });
+});
+
+describe('parseOrchestratorDecision, effort beside a combo', () => {
+  it('keeps an effort the combo supports', () => {
+    const decision = parseOrchestratorDecision({
+      raw: '<<orchestrator>>{"action":"next","reason":"x","step":{"name":"Plan","role":"planner","promptPrefix":"Plan it.","model":"claude-opus-5-thinking-high","effort":"high"}}<</orchestrator>>',
+      provider: 'cursor',
+    });
+
+    expect(decision?.action === 'next' && decision.step).toEqual({
+      name: 'Plan',
+      role: 'planner',
+      promptPrefix: 'Plan it.',
+      model: 'claude-opus-5-thinking-high',
+      effort: 'high',
+    });
+  });
+});

--- a/packages/core/src/orchestrator/parser.ts
+++ b/packages/core/src/orchestrator/parser.ts
@@ -1,5 +1,6 @@
-import type { ModelEffort, ProviderId } from '@goodboy/types';
+import type { ModelEffort, ModelSelection, ProviderId } from '@goodboy/types';
 import { providerEffortLevels } from '../providers/providerEffortLevels';
+import { resolvedStoredModelId } from '../providers/resolvedStoredModelId';
 import { resolveStoredModelSelection } from '../providers/resolveStoredModelSelection';
 import { isAgentRole } from '../roles';
 import { structuredRunSummary } from './runSummary';
@@ -109,7 +110,7 @@ type ModelParams = {
   readonly id: string | null;
 };
 
-const validModel = ({ provider, id }: ModelParams): string | null => {
+const validSelection = ({ provider, id }: ModelParams): ModelSelection | null => {
   if (id === null) {
     return null;
   }
@@ -117,7 +118,7 @@ const validModel = ({ provider, id }: ModelParams): string | null => {
   if (stored.report?.kind === 'unknown') {
     return null;
   }
-  return stored.selection.key;
+  return stored.selection;
 };
 
 type EffortParams = {
@@ -151,8 +152,13 @@ const parseStep = ({ value, provider }: StepParams): OrchestratorStep | null => 
   if (name === null || promptPrefix === null) {
     return null;
   }
-  const model = validModel({ provider, id: nonEmptyString(step['model']) });
-  const effort = validEffort({ provider, model, level: nonEmptyString(step['effort']) });
+  const selection = validSelection({ provider, id: nonEmptyString(step['model']) });
+  const model = selection === null ? null : resolvedStoredModelId({ provider, selection });
+  const effort = validEffort({
+    provider,
+    model: selection?.key ?? null,
+    level: nonEmptyString(step['effort']),
+  });
   return {
     name,
     role: role !== null && isAgentRole(role) ? role : 'custom',

--- a/packages/core/src/providers/canonicalModelId.test.ts
+++ b/packages/core/src/providers/canonicalModelId.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { getDefaultTurnModel } from './capabilities';
 import { canonicalModelId } from './canonicalModelId';
 import { resolveModelIdForProvider } from './resolveModelIdForProvider';
 
@@ -82,5 +83,29 @@ describe('resolveModelIdForProvider', () => {
     expect(resolveModelIdForProvider({ provider: 'cursor', modelId: 'composer-2.5' })).not.toBe(
       'composer-2.5-fast',
     );
+  });
+});
+
+describe('canonicalModelId, ids nobody can resolve', () => {
+  it('refuses to name an execution for an id no provider offers', () => {
+    expect(canonicalModelId({ provider: 'cursor', modelId: 'not-a-model' })).toBeNull();
+    expect(canonicalModelId({ provider: 'anthropic', modelId: 'not-a-model' })).toBeNull();
+  });
+
+  it('never reads an unknown id as the provider default', () => {
+    expect(canonicalModelId({ provider: 'anthropic', modelId: 'not-a-model' })).not.toBe(
+      canonicalModelId({
+        provider: 'anthropic',
+        modelId: getDefaultTurnModel({ id: 'anthropic' }),
+      }),
+    );
+    expect(canonicalModelId({ provider: 'cursor', modelId: 'not-a-model' })).not.toBe(
+      canonicalModelId({ provider: 'cursor', modelId: getDefaultTurnModel({ id: 'cursor' }) }),
+    );
+  });
+
+  it('keeps two different unknown ids from agreeing with each other', () => {
+    expect(canonicalModelId({ provider: 'cursor', modelId: 'not-a-model' })).toBeNull();
+    expect(canonicalModelId({ provider: 'cursor', modelId: 'also-not-a-model' })).toBeNull();
   });
 });

--- a/packages/core/src/providers/canonicalModelId.test.ts
+++ b/packages/core/src/providers/canonicalModelId.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { canonicalModelId } from './canonicalModelId';
+import { resolveModelIdForProvider } from './resolveModelIdForProvider';
+
+describe('canonicalModelId', () => {
+  it('reads a cursor key and its base slug as the same execution', () => {
+    expect(canonicalModelId({ provider: 'cursor', modelId: 'composer-2.5' })).toBe(
+      canonicalModelId({ provider: 'cursor', modelId: 'composer-2.5' }),
+    );
+    expect(canonicalModelId({ provider: 'cursor', modelId: 'composer-2.5' })).toBe('composer-2.5');
+  });
+
+  it('keeps the cursor fast combo apart from the base model', () => {
+    expect(canonicalModelId({ provider: 'cursor', modelId: 'composer-2.5-fast' })).toBe(
+      'composer-2.5-fast',
+    );
+    expect(canonicalModelId({ provider: 'cursor', modelId: 'composer-2.5-fast' })).not.toBe(
+      canonicalModelId({ provider: 'cursor', modelId: 'composer-2.5' }),
+    );
+  });
+
+  it('keeps the cursor thinking combo apart from the non thinking one', () => {
+    expect(
+      canonicalModelId({ provider: 'cursor', modelId: 'claude-4.6-sonnet-medium-thinking' }),
+    ).toBe('claude-4.6-sonnet-medium-thinking');
+    expect(
+      canonicalModelId({ provider: 'cursor', modelId: 'claude-4.6-sonnet-medium-thinking' }),
+    ).not.toBe(canonicalModelId({ provider: 'cursor', modelId: 'sonnet-4.6' }));
+  });
+
+  it('reads the codex astra key and its cli id as the same execution', () => {
+    expect(canonicalModelId({ provider: 'codex', modelId: 'gpt-6' })).toBe(
+      canonicalModelId({ provider: 'codex', modelId: 'gpt-6-astra' }),
+    );
+  });
+
+  it('reads an anthropic key and its cli id as the same execution', () => {
+    expect(canonicalModelId({ provider: 'anthropic', modelId: 'opus-5' })).toBe(
+      canonicalModelId({ provider: 'anthropic', modelId: 'claude-opus-5' }),
+    );
+  });
+
+  it('keeps sol, terra and luna independent', () => {
+    const sol = canonicalModelId({ provider: 'codex', modelId: 'gpt-5.6-sol' });
+    const terra = canonicalModelId({ provider: 'codex', modelId: 'gpt-5.6-terra' });
+    const luna = canonicalModelId({ provider: 'codex', modelId: 'gpt-5.6-luna' });
+    expect(new Set([sol, terra, luna]).size).toBe(3);
+    expect(sol).toBe('gpt-5.6-sol');
+    expect(luna).toBe('gpt-5.6-luna');
+  });
+});
+
+describe('resolveModelIdForProvider', () => {
+  it('returns the plain key when the model carries no axes', () => {
+    expect(resolveModelIdForProvider({ provider: 'cursor', modelId: 'composer-2.5' })).toBe(
+      'composer-2.5',
+    );
+    expect(resolveModelIdForProvider({ provider: 'anthropic', modelId: 'claude-opus-5' })).toBe(
+      'opus-5',
+    );
+  });
+
+  it('keeps the cursor combo when the id carries one', () => {
+    expect(resolveModelIdForProvider({ provider: 'cursor', modelId: 'composer-2.5-fast' })).toBe(
+      'composer-2.5-fast',
+    );
+    expect(
+      resolveModelIdForProvider({
+        provider: 'cursor',
+        modelId: 'claude-4.6-sonnet-medium-thinking',
+      }),
+    ).toBe('claude-4.6-sonnet-medium-thinking');
+  });
+
+  it('still remaps an id that belongs to another provider', () => {
+    expect(resolveModelIdForProvider({ provider: 'cursor', modelId: 'claude-sonnet-4-6' })).toBe(
+      'sonnet-4.6',
+    );
+  });
+
+  it('never reinterprets a collapsed id as a combo', () => {
+    expect(resolveModelIdForProvider({ provider: 'cursor', modelId: 'composer-2.5' })).not.toBe(
+      'composer-2.5-fast',
+    );
+  });
+});

--- a/packages/core/src/providers/canonicalModelId.ts
+++ b/packages/core/src/providers/canonicalModelId.ts
@@ -1,14 +1,16 @@
 import type { ProviderId } from '@goodboy/types';
+import { matchModelSelectionForProvider } from './model-map';
 import { modelIdForSelection } from './modelIdForSelection';
-import { resolveModelSelectionForProvider } from './model-map';
 
 type Params = {
   readonly provider: ProviderId;
   readonly modelId: string;
 };
 
-export const canonicalModelId = ({ provider, modelId }: Params): string =>
-  modelIdForSelection({
-    provider,
-    selection: resolveModelSelectionForProvider({ provider, modelId }),
-  });
+export const canonicalModelId = ({ provider, modelId }: Params): string | null => {
+  const selection = matchModelSelectionForProvider({ provider, modelId });
+  if (selection == null) {
+    return null;
+  }
+  return modelIdForSelection({ provider, selection });
+};

--- a/packages/core/src/providers/canonicalModelId.ts
+++ b/packages/core/src/providers/canonicalModelId.ts
@@ -1,0 +1,14 @@
+import type { ProviderId } from '@goodboy/types';
+import { modelIdForSelection } from './modelIdForSelection';
+import { resolveModelSelectionForProvider } from './model-map';
+
+type Params = {
+  readonly provider: ProviderId;
+  readonly modelId: string;
+};
+
+export const canonicalModelId = ({ provider, modelId }: Params): string =>
+  modelIdForSelection({
+    provider,
+    selection: resolveModelSelectionForProvider({ provider, modelId }),
+  });

--- a/packages/core/src/providers/model-map.ts
+++ b/packages/core/src/providers/model-map.ts
@@ -1,4 +1,4 @@
-import type { ProviderId } from '@goodboy/types';
+import type { ModelSelection, ProviderId } from '@goodboy/types';
 import { defaultModelSelection } from './defaultModelSelection';
 import { MODEL_CATALOGS } from './catalogs';
 import { parseLegacyId } from './parseLegacyId';
@@ -25,15 +25,15 @@ type ProvidersAreTotal =
   Exclude<ProviderId, (typeof PROVIDERS)[number]> extends never ? true : false;
 type _ProvidersTotalCheck = Expect<ProvidersAreTotal>;
 
-export const resolveModelForProvider = ({ provider, modelId }: Params): string => {
+export const resolveModelSelectionForProvider = ({ provider, modelId }: Params): ModelSelection => {
   const keyed = MODEL_CATALOGS[provider].find((model) => model.key === modelId);
   if (keyed != null) {
-    return keyed.key;
+    return { key: keyed.key };
   }
   const direct =
     selectionFromCliId({ provider, id: modelId }) ?? parseLegacyId({ provider, id: modelId });
   if (direct != null) {
-    return direct.key;
+    return direct;
   }
   for (const sourceProvider of PROVIDERS) {
     if (sourceProvider === provider) {
@@ -50,7 +50,10 @@ export const resolveModelForProvider = ({ provider, modelId }: Params): string =
       targetProvider: provider,
       selection: source,
     });
-    return remapped.selection.key;
+    return remapped.selection;
   }
-  return defaultModelSelection({ provider }).key;
+  return defaultModelSelection({ provider });
 };
+
+export const resolveModelForProvider = ({ provider, modelId }: Params): string =>
+  resolveModelSelectionForProvider({ provider, modelId }).key;

--- a/packages/core/src/providers/model-map.ts
+++ b/packages/core/src/providers/model-map.ts
@@ -25,7 +25,10 @@ type ProvidersAreTotal =
   Exclude<ProviderId, (typeof PROVIDERS)[number]> extends never ? true : false;
 type _ProvidersTotalCheck = Expect<ProvidersAreTotal>;
 
-export const resolveModelSelectionForProvider = ({ provider, modelId }: Params): ModelSelection => {
+export const matchModelSelectionForProvider = ({
+  provider,
+  modelId,
+}: Params): ModelSelection | null => {
   const keyed = MODEL_CATALOGS[provider].find((model) => model.key === modelId);
   if (keyed != null) {
     return { key: keyed.key };
@@ -52,8 +55,11 @@ export const resolveModelSelectionForProvider = ({ provider, modelId }: Params):
     });
     return remapped.selection;
   }
-  return defaultModelSelection({ provider });
+  return null;
 };
+
+export const resolveModelSelectionForProvider = ({ provider, modelId }: Params): ModelSelection =>
+  matchModelSelectionForProvider({ provider, modelId }) ?? defaultModelSelection({ provider });
 
 export const resolveModelForProvider = ({ provider, modelId }: Params): string =>
   resolveModelSelectionForProvider({ provider, modelId }).key;

--- a/packages/core/src/providers/planTurnFallback.test.ts
+++ b/packages/core/src/providers/planTurnFallback.test.ts
@@ -329,3 +329,88 @@ describe('planTurnFallback', () => {
     expect(plans).not.toContainEqual({ provider: 'anthropic', model: 'opus-5' });
   });
 });
+
+describe('planTurnFallback, ids that carry combo axes', () => {
+  it('honours a role fallback configured with a cursor combo slug', () => {
+    expect(
+      planTurnFallback({
+        failure: 'rate_limit',
+        provider: 'anthropic',
+        model: 'opus-5',
+        attempt: 0,
+        connectedProviders: ['anthropic', 'cursor'],
+        preferred: { provider: 'cursor', model: 'composer-2.5-fast' },
+      }),
+    ).toEqual({ provider: 'cursor', model: 'composer-2.5-fast' });
+  });
+
+  it('still ignores a role fallback naming a model no provider offers', () => {
+    expect(
+      planTurnFallback({
+        failure: 'rate_limit',
+        provider: 'anthropic',
+        model: 'opus-5',
+        attempt: 0,
+        connectedProviders: ['anthropic', 'cursor'],
+        preferred: { provider: 'cursor', model: 'not-a-model' },
+      }),
+    ).not.toEqual({ provider: 'cursor', model: 'not-a-model' });
+  });
+
+  it('still refuses a role fallback that names the model that just failed', () => {
+    expect(
+      planTurnFallback({
+        failure: 'rate_limit',
+        provider: 'cursor',
+        model: 'composer-2.5',
+        attempt: 0,
+        connectedProviders: ['cursor', 'anthropic'],
+        preferred: { provider: 'cursor', model: 'composer-2.5' },
+      }),
+    ).not.toEqual({ provider: 'cursor', model: 'composer-2.5' });
+  });
+
+  it('repeats the executed combo when the provider is unreachable', () => {
+    expect(
+      planTurnFallback({
+        failure: 'unreachable',
+        provider: 'cursor',
+        model: 'composer-2.5-fast',
+        attempt: 0,
+        connectedProviders: ['cursor', 'anthropic'],
+      }),
+    ).toEqual({ provider: 'cursor', model: 'composer-2.5-fast' });
+  });
+
+  it('keeps the tier and weight of the failed model when the id carries a combo', () => {
+    expect(
+      planTurnFallback({
+        failure: 'unreachable',
+        provider: 'cursor',
+        model: 'composer-2.5-fast',
+        attempt: 1,
+        connectedProviders: ['cursor', 'anthropic'],
+      }),
+    ).toEqual(
+      planTurnFallback({
+        failure: 'unreachable',
+        provider: 'cursor',
+        model: 'composer-2.5',
+        attempt: 1,
+        connectedProviders: ['cursor', 'anthropic'],
+      }),
+    );
+  });
+
+  it('excludes the failed model even when the id carries a combo', () => {
+    const plan = planTurnFallback({
+      failure: 'model_not_available',
+      provider: 'cursor',
+      model: 'composer-2.5-fast',
+      attempt: 0,
+      connectedProviders: ['cursor'],
+    });
+
+    expect(plan?.model).not.toBe('composer-2.5');
+  });
+});

--- a/packages/core/src/providers/planTurnFallback.ts
+++ b/packages/core/src/providers/planTurnFallback.ts
@@ -1,5 +1,6 @@
 import type { ModelCostTier, ModelDescriptor, ProviderId } from '@goodboy/types';
 import { PROVIDER_CAPABILITIES } from './capabilities';
+import { resolveStoredModelSelection } from './resolveStoredModelSelection';
 
 export type TurnFailureKind =
   'authentication' | 'rate_limit' | 'usage_limit' | 'model_not_available' | 'unreachable' | 'other';
@@ -63,8 +64,14 @@ const tierIndex = ({ tier }: TierParams): number => {
   return COST_TIER_ORDER.indexOf(tier);
 };
 
+const descriptorKey = ({ provider, model }: DescriptorParams): string => {
+  const stored = resolveStoredModelSelection({ provider, id: model });
+  return stored.report?.kind === 'unknown' ? model : stored.selection.key;
+};
+
 const descriptorFor = ({ provider, model }: DescriptorParams): ModelDescriptor | null => {
-  return PROVIDER_CAPABILITIES[provider].models.find((candidate) => candidate.id === model) ?? null;
+  const key = descriptorKey({ provider, model });
+  return PROVIDER_CAPABILITIES[provider].models.find((candidate) => candidate.id === key) ?? null;
 };
 
 const pickClosest = ({
@@ -145,7 +152,10 @@ const preferredPlan = ({
   if (preferred == null) {
     return null;
   }
-  if (preferred.provider === provider && preferred.model === model) {
+  if (
+    preferred.provider === provider &&
+    descriptorKey({ provider, model: preferred.model }) === descriptorKey({ provider, model })
+  ) {
     return null;
   }
   if (!connectedProviders.includes(preferred.provider)) {
@@ -175,6 +185,7 @@ export const planTurnFallback = ({
     }
   }
   const failed = descriptorFor({ provider, model });
+  const failedKey = descriptorKey({ provider, model });
   const tier = failed?.costTier ?? 'mid';
   const weight = failed?.weight ?? null;
   if (failure === 'usage_limit') {
@@ -191,7 +202,7 @@ export const planTurnFallback = ({
       provider,
       tier,
       weight,
-      excludeModel: model,
+      excludeModel: failedKey,
       maxTierIndex: Math.max(tierIndex({ tier }) - 1, 0),
     });
     if (cheaper != null) {
@@ -203,7 +214,7 @@ export const planTurnFallback = ({
       provider,
       tier,
       weight,
-      excludeModel: model,
+      excludeModel: failedKey,
       maxTierIndex: null,
     });
     if (sibling != null) {

--- a/packages/core/src/providers/resolveModelIdForProvider.ts
+++ b/packages/core/src/providers/resolveModelIdForProvider.ts
@@ -1,0 +1,16 @@
+import type { ProviderId } from '@goodboy/types';
+import { modelIdForSelection } from './modelIdForSelection';
+import { resolveModelSelectionForProvider } from './model-map';
+import { resolvedStoredModelId } from './resolvedStoredModelId';
+
+type Params = {
+  readonly provider: ProviderId;
+  readonly modelId: string;
+};
+
+export const resolveModelIdForProvider = ({ provider, modelId }: Params): string => {
+  const selection = resolveModelSelectionForProvider({ provider, modelId });
+  const resolved = resolvedStoredModelId({ provider, selection });
+  const base = modelIdForSelection({ provider, selection: { key: selection.key } });
+  return resolved === base ? selection.key : resolved;
+};


### PR DESCRIPTION
Turn Fast on, close the routing pill, reopen it: the toggle reads off. The turn still sends Fast, at six times the base rate. That is the visible end of a defect that runs through seven boundaries.

## The shape of it

`resolveModelForProvider` is a key normalizer, and that is correct: `clampEffort`, `modelCandidates` and the Max Mode advisory all look descriptors up by key. The defect is that the collapsed key then reached consumers that need the combo axes, so `composer-2.5-fast` became `composer-2.5` and a deliberate choice was dropped without a word.

Cursor prices the two slugs at 0.5/2.5 and 3/15 per Mtok. They are one catalog key with two combos, which is the right shape and is not changed here. Thinking is the same story: Sonnet 4.6 has false and true combos, and Opus 5 pairs non-thinking with low and thinking with high, so there the collapse moved the resolved effort too.

## The boundaries

**The picker showed the wrong state.** `useTurnRouting` kept `effectiveSelection` private and published only the key, so the picker rebuilt an impoverished selection and redrew Fast as off, resynchronising the draft that way on every close. The hook now publishes the selection and an id that carries the combo.

**"Using default" was wrong, and hid the reset.** The override check compared two keys, so a difference that was only a combo read as no difference at all. Both sides are now canonicalised the same way, including the agent-less branch of the reference routing.

**Both retries dropped the combo.** The timed usage-limit retry and the `unreachable` branch of `planTurnFallback`, whose first attempt echoes the model back, each carried `modelSelection.key`. Both now carry what actually ran. `planTurnFallback` canonicalises internally for the descriptor lookup, the exclusion and the "preferred equals the failed model" check, so tier, weight and exclusion do not degrade when the id carries a combo.

**The orchestrator parser** recognised the slug and then returned only the key. It now returns the resolved id, and the effort ladder is read off the key so a slug plus an effort no longer loses the effort. Pool enforcement compares canonical executions, so `gpt-6` accepts `gpt-6-astra`, while `composer-2.5-fast` against a base-only pool is still refused and Sol, Terra and Luna stay apart.

**A fallback configured with a slug was ignored**, because `preferredPlan` matched only exact descriptor ids. The complementary problem: a slug arriving where a key was expected.

**The mismatch warning was blind in one direction and about to become noisy in the other.** It compared keys, so it could not see a Fast to base substitution, and it would have fired falsely once slugs started arriving. It now compares resolved executions.

## One thing the review did not predict

`remapModelSelection` stamps the target's default toggles onto a cross-provider selection, so resolving naively there turns `claude-sonnet-4-6` into `claude-4.6-sonnet-medium` on every remap. The new resolver returns the plain key whenever the resolved id equals the base id, so remaps still land where they did.

## What did not change, deliberately

No second catalog key for Fast. It would not fix thinking, the inconsistent comparisons or effort serialization, and it would change the catalog contract for one provider's toggle.

Max Mode is not an independent axis and no current case exists where the collapse alone changes it; the advisory cache stays keyed by key. `routingOverride.model` still carries the key, since the axes already ride in its selection and changing it would push slugs into the budget router for no gain.

The right-size nudge had a real wrong input: the heavier ratio is suggested over current, so the base price at the denominator overstated it sixfold, `10` where the Fast identity gives `1.7`. **No user-visible number changes today**: for Composer the suggestion is `strong`, which prints no multiplier, and every cursor model whose combos differ shares one price across them. The test locks that in rather than leaving it to be rediscovered.

The pill text still omits Fast, because `modelLabel` maps both slugs to the shared descriptor. That is a separate gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
