### PR TITLE
fix(desktop): give the combo fixture the mount identity it needs

### DIFF
--- a/apps/desktop/src/store/store.turn-combo-identity.test.ts
+++ b/apps/desktop/src/store/store.turn-combo-identity.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import type {
   AgentId,
   IsoDateTime,
+  MountId,
   ProjectId,
   SessionId,
+  SessionProjectMount,
   TurnProviderOverride,
   WorkspaceId,
 } from '@goodboy/types';
@@ -90,6 +92,22 @@ const mockRouting = async (fallbackUsed: boolean) => {
   });
 };
 
+const COMBO_MOUNT: SessionProjectMount = {
+  mountId: 'mount-combo' as MountId,
+  sessionId: SESSION_ID,
+  projectId: 'project-combo' as ProjectId,
+  mountName: 'repo',
+  worktreePath: '/tmp/wt',
+  repoRoot: '/tmp/repo',
+  branch: 'goodboy/combo',
+  lastWorktreePath: null,
+  baseBranch: null,
+  parallelIndex: 0,
+  isAttached: true,
+  diskState: 'present',
+  revision: 0,
+};
+
 describe('sendTurn keeps the executed combo across a retry', () => {
   beforeEach(async () => {
     resetStorySpies();
@@ -120,15 +138,7 @@ describe('sendTurn keeps the executed combo across a retry', () => {
       projects: [],
       sessionWorktrees: { [SESSION_ID]: ['/tmp/wt'] },
       sessionProjectMounts: {
-        [SESSION_ID]: [
-          {
-            projectId: 'project-combo' as ProjectId,
-            mountName: 'repo',
-            worktreePath: '/tmp/wt',
-            repoRoot: '/tmp/repo',
-            branch: 'goodboy/combo',
-          },
-        ],
+        [SESSION_ID]: [COMBO_MOUNT],
       },
       sessionPhaseRuns: {
         [SESSION_ID]: [buildStoryAgent({ id: AGENT_A, sessionId: SESSION_ID, name: 'agent 0' })],
@@ -250,15 +260,7 @@ describe('sendTurn checks the model it ran against the model that was picked', (
       projects: [],
       sessionWorktrees: { [SESSION_ID]: ['/tmp/wt'] },
       sessionProjectMounts: {
-        [SESSION_ID]: [
-          {
-            projectId: 'project-combo' as ProjectId,
-            mountName: 'repo',
-            worktreePath: '/tmp/wt',
-            repoRoot: '/tmp/repo',
-            branch: 'goodboy/combo',
-          },
-        ],
+        [SESSION_ID]: [COMBO_MOUNT],
       },
       sessionPhaseRuns: {
         [SESSION_ID]: [buildStoryAgent({ id: AGENT_A, sessionId: SESSION_ID, name: 'agent 0' })],


### PR DESCRIPTION
main does not typecheck. I broke it.

#1746 added `store.turn-combo-identity.test.ts` with a mount fixture carrying five fields. #1747 made `mountId`, `sessionId`, `lastWorktreePath`, `baseBranch`, `parallelIndex`, `isAttached`, `diskState` and `revision` mandatory on `SessionProjectMount`. Each was green against the main it was built on. Neither run saw the other, and I merged them in sequence without rebasing the second onto the first.

The fixture is now a named constant with the full identity, used by both call sites rather than repeated.

`pnpm typecheck`: 5 successful, 5 total. `store.turn-combo-identity.test.ts`: 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)