### PR TITLE
chore(repo): bump version to 0.2.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.2.28
+
+Every step of a workflow now runs on a model picked for that step, shown on the
+node and yours to override.
+
+### [#1752] The orchestrator chooses the model for each step
+
+A step used to fall back on the role defaults however the plan was written.
+Each one now gets its own provider and model, taken from the models you have
+connected that are neither cooling down nor blocked, and your configured
+defaults are what happens when nobody chose.
+
+The choice sits on the node with a short reason for it. Open it and you get the
+models within reach, the efforts each supports and the published price, and you
+can pin a step to one model or hand it back. A pin you set wins over anything
+the plan asked for. When a step fans out, each child resolves its own model from
+its own work instead of inheriting the parent's.
+
+If the model a step was running on goes away, Goodboy replaces it with one in
+the same price tier, which matches what it costs rather than what it can do. No
+model in the catalog carries a hand-graded score for ability, so every one of
+them is a full candidate. The step menu and the per-child choice both ship on,
+and `VITE_WORKFLOW_MODEL_METADATA=false` and
+`VITE_WORKFLOW_CHILD_MODEL_SELECTION=false` turn them off one at a time.
+
+### Fixes
+
+- The Custom tab in the workflow builder can be written by hand, without running
+  the planner first. [#1752]
+- Re-planning threw away hand-written steps before it knew the new plan had
+  worked. It keeps them until it does. [#1752]
+- A refusal could name a model that never ran. It names the one it turned down.
+  [#1752]
+- A model pinned for a run was dropped without a word when its provider went
+  cold. The run now says so and stops. [#1752]
+- Preset workflows and new sessions started on models that were out of reach.
+  They check first. [#1752]
+- A fan-out child could lose the model pinned for the run. [#1752]
+- A plan carrying a single unfamiliar field was discarded whole, and in silence.
+  [#1752]
+- A model still inside budget was swapped out as soon as a spend warning
+  appeared. [#1752]
+
 ## Goodboy v0.2.27
 
 A project can hold several worktrees in one session and every command, fix and

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.2.27"
+version = "0.2.28"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.2.27',
+  version: 'v0.2.28',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
Bumps the version to 0.2.28 across the six places in `docs/release.md` (root `package.json`, `apps/desktop/package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, `website/src/site.ts`) and adds the `## Goodboy v0.2.28` section to `CHANGELOG.md`.

Notes written from the body of #1752, the only app-facing change in this release.

Test plan: version-only change plus changelog prose. CI green is the check.