### PR TITLE
chore(repo): bump version to 0.2.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.2.29
+
+A workflow that works across more than one repository keeps running instead of
+stopping to ask which one it writes in.
+
+### [#1754] Workflow steps pick their own repository
+
+A session that mounts two repositories used to stop every step it started, with
+the turn refused until you chose which mount to write in. Steps now pick one on
+their own: the mount you chose if you chose one, otherwise the first the session
+took. The pick lasts for that turn only and never replaces a choice you made.
+
+The workflow now says which mount its steps are writing in, and the same control
+lets you pin a different one for every turn after it. A retry that waits out a
+provider limit comes back to the mount it started on rather than wherever the
+session points by then.
+
+Follow-up: a step that fails before it starts still shows as waiting rather than
+as blocked. Making those steps retryable from the workflow is the next release.
+
 ## Goodboy v0.2.28
 
 Every step of a workflow now runs on a model picked for that step, shown on the

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.2.28"
+version = "0.2.29"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/apps/desktop/src/features/chat/components/WriteDestinationControl/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/WriteDestinationControl/index.test.tsx
@@ -235,4 +235,31 @@ describe('WriteDestinationControl with siblings and no choice', () => {
       }),
     );
   });
+
+  it('names the automatic mount while leaving the picker available', () => {
+    store.sessionProjectMounts = {
+      [SESSION_ID]: [
+        {
+          ...mount({ mountId: MOUNT_MAIN, mountName: 'main', branch: 'ak/one' }),
+          parallelIndex: 2,
+        },
+        {
+          ...mount({ mountId: MOUNT_FEATURE, mountName: 'feature', branch: 'ak/two' }),
+          parallelIndex: 1,
+        },
+      ],
+    };
+
+    render(
+      <WriteDestinationControl sessionId={SESSION_ID} agentId={AGENT_ID} fallback="automatic" />,
+    );
+
+    expect(screen.getByText('Auto: web / feature / ak/two')).toBeDefined();
+    expect(
+      screen.getByTitle(
+        'No mount chosen for this session. Automated turns write to web / feature / ak/two (/sessions/one/feature) until you choose one.',
+      ),
+    ).toBeDefined();
+    expect(screen.getByRole('button', { name: /Write destination/ })).toBeDefined();
+  });
 });

--- a/apps/desktop/src/features/chat/components/WriteDestinationControl/index.tsx
+++ b/apps/desktop/src/features/chat/components/WriteDestinationControl/index.tsx
@@ -21,6 +21,7 @@ import { useWriteDestination } from './useWriteDestination';
 type Props = {
   readonly sessionId: SessionId;
   readonly agentId: AgentId | null;
+  readonly fallback?: 'automatic';
 };
 
 const MAX_LABEL_LENGTH = 46;
@@ -28,8 +29,12 @@ const MAX_LABEL_LENGTH = 46;
 const shorten = (label: string): string =>
   label.length > MAX_LABEL_LENGTH ? `${label.slice(0, MAX_LABEL_LENGTH - 1)}…` : label;
 
-export const WriteDestinationControl = ({ sessionId, agentId }: Props) => {
-  const { next, candidates, running, diverges } = useWriteDestination({ sessionId, agentId });
+export const WriteDestinationControl = ({ sessionId, agentId, fallback }: Props) => {
+  const { next, candidates, running, diverges, isAutomatic } = useWriteDestination({
+    sessionId,
+    agentId,
+    fallback,
+  });
   const setSessionActiveMount = useAppStore((state) => state.setSessionActiveMount);
   const { showToast } = useToast();
   const dropdown = useDropdown({ width: 'w-96', expectedHeight: 320 });
@@ -43,21 +48,25 @@ export const WriteDestinationControl = ({ sessionId, agentId }: Props) => {
 
   const isUnselected = next.kind === 'unselected';
 
-  const primaryLabel = isUnselected
-    ? 'Choose destination'
-    : running === null
-      ? `Write to: ${nextLabel}`
-      : diverges
-        ? `In progress: ${runningLabel}`
-        : `In progress and next turns: ${nextLabel}`;
+  const primaryLabel = isAutomatic
+    ? `Auto: ${nextLabel}`
+    : isUnselected
+      ? 'Choose destination'
+      : running === null
+        ? `Write to: ${nextLabel}`
+        : diverges
+          ? `In progress: ${runningLabel}`
+          : `In progress and next turns: ${nextLabel}`;
 
-  const primaryTitle = isUnselected
-    ? nextDetail
-    : running === null
-      ? `Writing to ${nextDetail}`
-      : diverges
-        ? `This turn started on ${runningDetail}. Next turns write to ${nextDetail} unless changed.`
-        : `This turn and the next ones write to ${nextDetail}.`;
+  const primaryTitle = isAutomatic
+    ? `No mount chosen for this session. Automated turns write to ${nextDetail} until you choose one.`
+    : isUnselected
+      ? nextDetail
+      : running === null
+        ? `Writing to ${nextDetail}`
+        : diverges
+          ? `This turn started on ${runningDetail}. Next turns write to ${nextDetail} unless changed.`
+          : `This turn and the next ones write to ${nextDetail}.`;
 
   const Icon = next.kind === 'scratch' ? CONCEPT_ICONS.folderOpen : CONCEPT_ICONS.worktree;
   const hasCandidates = candidates.length > 0;
@@ -85,13 +94,13 @@ export const WriteDestinationControl = ({ sessionId, agentId }: Props) => {
     }
   };
 
-  const currentMountId = next.kind === 'mount' ? next.mountId : null;
+  const currentMountId = isAutomatic || next.kind !== 'mount' ? null : next.mountId;
   const canApply = pendingMountId !== null && pendingMountId !== currentMountId;
 
   const trigger = (
     <Chip
       as="button"
-      tone={diverges || isUnselected ? 'warning' : 'neutral'}
+      tone={isAutomatic || diverges || isUnselected ? 'warning' : 'neutral'}
       size="xs"
       bordered={false}
       icon={<Icon size={ICON_SIZE.row} aria-hidden />}

--- a/apps/desktop/src/features/chat/components/WriteDestinationControl/useWriteDestination/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/WriteDestinationControl/useWriteDestination/index.test.tsx
@@ -107,4 +107,37 @@ describe('useWriteDestination, subscription scope', () => {
     expect(renderCount).toBe(2);
     expect(lastLabel).toBe(MOUNT_B);
   });
+
+  it('resolves the automatic fallback without selecting the session mount', () => {
+    testStore = buildStore();
+    testStore.setState({
+      sessionActiveMount: {},
+      sessionProjectMounts: {
+        [SESSION_ID]: [
+          { ...mount({ mountId: MOUNT_A, branch: 'ak/feat-a' }), parallelIndex: 2 },
+          { ...mount({ mountId: MOUNT_B, branch: 'ak/feat-b' }), parallelIndex: 1 },
+        ],
+        [OTHER_SESSION_ID]: [],
+      },
+    });
+    let selectedMountId: MountId | null = null;
+    let isAutomatic = false;
+
+    const Probe = () => {
+      const view = useWriteDestination({
+        sessionId: SESSION_ID,
+        agentId: AGENT_ID,
+        fallback: 'automatic',
+      });
+      selectedMountId = view.next.kind === 'mount' ? view.next.mountId : null;
+      isAutomatic = view.isAutomatic;
+      return null;
+    };
+
+    render(<Probe />);
+
+    expect(selectedMountId).toBe(MOUNT_B);
+    expect(isAutomatic).toBe(true);
+    expect(testStore.getState().sessionActiveMount[SESSION_ID]).toBeUndefined();
+  });
 });

--- a/apps/desktop/src/features/chat/components/WriteDestinationControl/useWriteDestination/index.ts
+++ b/apps/desktop/src/features/chat/components/WriteDestinationControl/useWriteDestination/index.ts
@@ -5,6 +5,7 @@ import {
   selectActiveMount,
   selectWritableMounts,
 } from '../../../../../store/slices/project-mounts/selectors';
+import { selectAutomaticTurnMount } from '../../../../../store/slices/project-mounts/selectAutomaticTurnMount';
 import {
   listWriteDestinationCandidates,
   resolveWriteDestination,
@@ -17,6 +18,7 @@ import { scratchDirPrepare } from '../../../../../features/worktree/worktree';
 type Params = {
   readonly sessionId: SessionId;
   readonly agentId: AgentId | null;
+  readonly fallback?: 'automatic';
 };
 
 export type WriteDestinationView = Readonly<{
@@ -24,9 +26,14 @@ export type WriteDestinationView = Readonly<{
   candidates: ReadonlyArray<WriteDestinationCandidate>;
   running: WriteDestination | null;
   diverges: boolean;
+  isAutomatic: boolean;
 }>;
 
-export const useWriteDestination = ({ sessionId, agentId }: Params): WriteDestinationView => {
+export const useWriteDestination = ({
+  sessionId,
+  agentId,
+  fallback,
+}: Params): WriteDestinationView => {
   const session = useAppStore((state) =>
     state.sessions.find((candidate) => candidate.id === sessionId),
   );
@@ -71,16 +78,25 @@ export const useWriteDestination = ({ sessionId, agentId }: Params): WriteDestin
     () => selectWritableMounts({ state: mountState, sessionId }),
     [mountState, sessionId],
   );
+  const automaticMount = useMemo(
+    () =>
+      fallback === 'automatic' && activeMount === null && writableMounts.length > 0
+        ? selectAutomaticTurnMount({ state: mountState, sessionId })
+        : null,
+    [activeMount, fallback, mountState, sessionId, writableMounts],
+  );
+  const nextMount = activeMount ?? automaticMount;
+  const isAutomatic = automaticMount !== null;
   const candidates = useMemo(
     () => listWriteDestinationCandidates({ mounts: writableMounts, projects }),
     [writableMounts, projects],
   );
   const activeProjectName = useMemo(
     () =>
-      activeMount === null
+      nextMount === null
         ? null
-        : (projects.find((project) => project.id === activeMount.projectId)?.name ?? null),
-    [activeMount, projects],
+        : (projects.find((project) => project.id === nextMount.projectId)?.name ?? null),
+    [nextMount, projects],
   );
 
   const [scratchPath, setScratchPath] = useState<string | null>(null);
@@ -104,16 +120,16 @@ export const useWriteDestination = ({ sessionId, agentId }: Params): WriteDestin
   const next = useMemo(
     () =>
       resolveWriteDestination({
-        mount: activeMount,
+        mount: nextMount,
         projectName: activeProjectName,
         scratchPath,
         mountCount: writableMounts.length,
       }),
-    [activeMount, activeProjectName, scratchPath, writableMounts],
+    [nextMount, activeProjectName, scratchPath, writableMounts],
   );
 
   const running = turnKind === 'running' ? turnDestination : null;
   const diverges = running !== null && !writeDestinationsMatch(running, next);
 
-  return { next, candidates, running, diverges };
+  return { next, candidates, running, diverges, isAutomatic };
 };

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
@@ -18,10 +18,15 @@ import type {
 import { TERMINAL_DIM } from '@goodboy/ui';
 import type { WorkflowBlockReason } from '../../../../workflows/advanceGate';
 
+type WriteDestinationProps = {
+  readonly fallback?: 'automatic';
+};
+
 const storeMocks = vi.hoisted(() => ({
   renameWorkflow: vi.fn(async () => undefined),
   orchestratingWorkflowRuns: {} as Record<string, boolean>,
   runSpendUsd: 0,
+  sessionProjectMounts: {} as Record<string, ReadonlyArray<Record<string, unknown>>>,
 }));
 
 vi.mock('../../../../../store', () => ({
@@ -33,7 +38,15 @@ vi.mock('../../../../../store', () => ({
       renameWorkflow: storeMocks.renameWorkflow,
       orchestratingWorkflowRuns: storeMocks.orchestratingWorkflowRuns,
       agentEffortOverride: {},
+      sessionMounts: {},
+      sessionProjectMounts: storeMocks.sessionProjectMounts,
     }),
+}));
+
+vi.mock('../../../../chat/components/WriteDestinationControl', () => ({
+  WriteDestinationControl: ({ fallback }: WriteDestinationProps) => (
+    <div data-testid="write-destination-control">{fallback}</div>
+  ),
 }));
 
 vi.mock(
@@ -208,6 +221,7 @@ const renderDetail = ({
 
 beforeEach(() => {
   storeMocks.renameWorkflow.mockClear();
+  storeMocks.sessionProjectMounts = {};
 });
 
 afterEach(() => {
@@ -217,6 +231,30 @@ afterEach(() => {
 });
 
 describe('WorkflowRow detail dashboard', () => {
+  it('shows the automatic write destination when the session has two mounts', () => {
+    storeMocks.sessionProjectMounts = { [SESSION_ID]: [{}, {}] };
+
+    renderDetail();
+
+    expect(screen.getByTestId('write-destination-control').textContent).toBe('automatic');
+  });
+
+  it('hides the write destination when the session has one mount', () => {
+    storeMocks.sessionProjectMounts = { [SESSION_ID]: [{}] };
+
+    renderDetail();
+
+    expect(screen.queryByTestId('write-destination-control')).toBeNull();
+  });
+
+  it('hides the write destination when the run is discarded', () => {
+    storeMocks.sessionProjectMounts = { [SESSION_ID]: [{}, {}] };
+
+    renderDetail({ runOverride: { ...run, discardedAt: NOW } });
+
+    expect(screen.queryByTestId('write-destination-control')).toBeNull();
+  });
+
   it('declares navigation and lifecycle action slots', () => {
     renderDetail();
 

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -23,6 +23,7 @@ import type {
 } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore, useRunSpendUsd } from '../../../../../store';
 import type { AppStore } from '../../../../../store/store';
+import { selectWritableMounts } from '../../../../../store/slices/project-mounts/selectors';
 import { inferAgentKindFromName, type AgentKind } from '../../../../../features/session/agent-kind';
 import { agentRoutingOverrides } from '../../../../../features/workflows/agentRoutingOverrides';
 import { resolveStepRouting } from '../../../../../features/workflows/resolveStepRouting';
@@ -36,6 +37,7 @@ import { WorkflowAutorunToggle } from '../../../../../features/workflows/compone
 import { useWorkflowTitleRename } from '../../../../../features/workflows/hooks/useWorkflowTitleRename';
 import { WorkflowStepGraph } from '../../../../../features/workflows/components/WorkflowStepGraph';
 import { GoalAttachmentsStrip } from '../../../../../features/context/components/ContextPanel/strips/GoalAttachmentsStrip';
+import { WriteDestinationControl } from '../../../../chat/components/WriteDestinationControl';
 import { CostBadge } from '../../../../providers/components/CostBadge';
 import { CardAction } from '@goodboy/ui';
 import { CardActionSlot } from '@goodboy/ui';
@@ -148,6 +150,9 @@ export const WorkflowRow = ({
   const sessionEffort = task.effort ?? null;
   const isOrchestrating = useAppStore((s) => s.orchestratingWorkflowRuns?.[run.id] ?? false);
   const restoreWorkflow = useAppStore((s) => s.restoreWorkflow);
+  const writableMountCount = useAppStore(
+    (state) => selectWritableMounts({ state, sessionId: task.id }).length,
+  );
   const workflowRun = run;
   const isDiscarded = run.discardedAt != null;
   const wfAgents = agentsByRunId.get(run.id) ?? EMPTY_ARRAY;
@@ -407,6 +412,9 @@ export const WorkflowRow = ({
       </div>
       {expanded ? (
         <div className="col-span-2 row-start-2 flex flex-col gap-2">
+          {isDetail && !isDiscarded && writableMountCount > 1 ? (
+            <WriteDestinationControl sessionId={task.id} agentId={null} fallback="automatic" />
+          ) : null}
           {isDetail && expanded ? (
             <div className="flex flex-col gap-2">
               <WorkflowRunAsk

--- a/apps/desktop/src/store/slices/project-mounts/selectAutomaticTurnMount.test.ts
+++ b/apps/desktop/src/store/slices/project-mounts/selectAutomaticTurnMount.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  IsoDateTime,
+  MountId,
+  ProjectId,
+  SessionId,
+  SessionMountView,
+  SessionProjectMount,
+} from '@goodboy/types';
+import { selectAutomaticTurnMount } from './selectAutomaticTurnMount';
+
+const SESSION_ID = 'session-1' as SessionId;
+const PROJECT_ID = 'project-1' as ProjectId;
+const NOW = '2026-09-12T00:00:00.000Z' as IsoDateTime;
+
+type MountParams = {
+  readonly mountId: string;
+  readonly parallelIndex: number;
+};
+
+const mount = ({ mountId, parallelIndex }: MountParams): SessionProjectMount => ({
+  mountId: mountId as MountId,
+  sessionId: SESSION_ID,
+  projectId: PROJECT_ID,
+  mountName: mountId,
+  worktreePath: `/worktrees/${mountId}`,
+  lastWorktreePath: null,
+  repoRoot: '/repo',
+  branch: `feature/${mountId}`,
+  baseBranch: 'main',
+  parallelIndex,
+  isAttached: true,
+  diskState: 'present',
+  revision: 0,
+});
+
+type ViewParams = MountParams & {
+  readonly diskState: SessionMountView['diskState'];
+};
+
+const view = ({ mountId, parallelIndex, diskState }: ViewParams): SessionMountView => ({
+  id: mountId as MountId,
+  sessionId: SESSION_ID,
+  projectId: PROJECT_ID,
+  mountName: mountId,
+  worktreePath: `/worktrees/${mountId}`,
+  lastWorktreePath: null,
+  repoRoot: '/repo',
+  branch: `feature/${mountId}`,
+  baseBranch: 'main',
+  parallelIndex,
+  isAttached: true,
+  diskState,
+  revision: 0,
+  repoSlug: null,
+  createdAt: NOW,
+  updatedAt: NOW,
+});
+
+type SelectFromParams = {
+  readonly mounts: ReadonlyArray<SessionProjectMount>;
+};
+
+const selectFrom = ({ mounts }: SelectFromParams) =>
+  selectAutomaticTurnMount({
+    state: { sessionMounts: {}, sessionProjectMounts: { [SESSION_ID]: mounts } },
+    sessionId: SESSION_ID,
+  });
+
+describe('selectAutomaticTurnMount', () => {
+  it('picks the mount with the lowest parallel index', () => {
+    const selected = selectFrom({
+      mounts: [
+        mount({ mountId: 'mount-high', parallelIndex: 3 }),
+        mount({ mountId: 'mount-low', parallelIndex: 1 }),
+      ],
+    });
+
+    expect(selected?.mountId).toBe('mount-low');
+  });
+
+  it('breaks an index tie with the lexicographically smallest mount id', () => {
+    const selected = selectFrom({
+      mounts: [
+        mount({ mountId: 'mount-z', parallelIndex: 1 }),
+        mount({ mountId: 'mount-a', parallelIndex: 1 }),
+      ],
+    });
+
+    expect(selected?.mountId).toBe('mount-a');
+  });
+
+  it('returns the same mount when the input order is reversed', () => {
+    const mounts = [
+      mount({ mountId: 'mount-z', parallelIndex: 1 }),
+      mount({ mountId: 'mount-a', parallelIndex: 1 }),
+      mount({ mountId: 'mount-low', parallelIndex: 0 }),
+    ];
+
+    expect(selectFrom({ mounts })?.mountId).toBe('mount-low');
+    expect(selectFrom({ mounts: [...mounts].reverse() })?.mountId).toBe('mount-low');
+  });
+
+  it('does not mutate the input array', () => {
+    const mounts = [
+      mount({ mountId: 'mount-z', parallelIndex: 2 }),
+      mount({ mountId: 'mount-a', parallelIndex: 1 }),
+    ];
+    const before = [...mounts];
+
+    selectFrom({ mounts });
+
+    expect(mounts).toEqual(before);
+  });
+
+  it('returns null when there are no writable mounts', () => {
+    expect(selectFrom({ mounts: [] })).toBeNull();
+  });
+
+  it('excludes missing and removed mount views', () => {
+    const selected = selectAutomaticTurnMount({
+      state: {
+        sessionProjectMounts: {},
+        sessionMounts: {
+          [SESSION_ID]: [
+            view({ mountId: 'mount-missing', parallelIndex: 0, diskState: 'missing' }),
+            view({ mountId: 'mount-removed', parallelIndex: 1, diskState: 'removed' }),
+            view({ mountId: 'mount-present', parallelIndex: 2, diskState: 'present' }),
+          ],
+        },
+      },
+      sessionId: SESSION_ID,
+    });
+
+    expect(selected?.mountId).toBe('mount-present');
+  });
+});

--- a/apps/desktop/src/store/slices/project-mounts/selectAutomaticTurnMount.ts
+++ b/apps/desktop/src/store/slices/project-mounts/selectAutomaticTurnMount.ts
@@ -1,0 +1,31 @@
+import type { SessionId, SessionProjectMount } from '@goodboy/types';
+import type { AppState } from '../../types';
+import { selectWritableMounts } from './selectors';
+
+type Params = {
+  readonly state: Pick<AppState, 'sessionMounts' | 'sessionProjectMounts'>;
+  readonly sessionId: SessionId;
+};
+
+export const selectAutomaticTurnMount = ({
+  state,
+  sessionId,
+}: Params): SessionProjectMount | null =>
+  selectWritableMounts({ state, sessionId }).reduce<SessionProjectMount | null>(
+    (selected, candidate) => {
+      if (selected === null) {
+        return candidate;
+      }
+      if (candidate.parallelIndex < selected.parallelIndex) {
+        return candidate;
+      }
+      if (
+        candidate.parallelIndex === selected.parallelIndex &&
+        candidate.mountId < selected.mountId
+      ) {
+        return candidate;
+      }
+      return selected;
+    },
+    null,
+  );

--- a/apps/desktop/src/store/slices/project-mounts/selectedMountId.test.ts
+++ b/apps/desktop/src/store/slices/project-mounts/selectedMountId.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import type { MountId, SessionId } from '@goodboy/types';
+import { selectSelectedMountId } from './selectedMountId';
+
+const SESSION_ID = 'session-1' as SessionId;
+const PERSISTED = 'mount-persisted' as MountId;
+const EXPLICIT = 'mount-explicit' as MountId;
+
+const session = { id: SESSION_ID, activeMountId: PERSISTED } as never;
+
+describe('selectSelectedMountId', () => {
+  it('consults the persisted value when the in-memory entry is absent', () => {
+    expect(
+      selectSelectedMountId({
+        state: { sessions: [session], sessionActiveMount: {} },
+        sessionId: SESSION_ID,
+      }),
+    ).toBe(PERSISTED);
+  });
+
+  it('uses an explicit in-memory id instead of the persisted value', () => {
+    expect(
+      selectSelectedMountId({
+        state: { sessions: [session], sessionActiveMount: { [SESSION_ID]: EXPLICIT } },
+        sessionId: SESSION_ID,
+      }),
+    ).toBe(EXPLICIT);
+  });
+
+  it('keeps an explicit null as a cleared selection', () => {
+    expect(
+      selectSelectedMountId({
+        state: { sessions: [session], sessionActiveMount: { [SESSION_ID]: null } },
+        sessionId: SESSION_ID,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -116,6 +116,7 @@ import {
   selectMountById,
   selectWritableMounts,
 } from '../project-mounts/selectors';
+import { selectAutomaticTurnMount } from '../project-mounts/selectAutomaticTurnMount';
 import { resolveWriteDestination } from '../project-mounts/writeDestination';
 import {
   mountContinuationPrompt,
@@ -163,7 +164,7 @@ type Input = {
   attachments?: ReadonlyArray<AttachmentInput>;
   override?: TurnProviderOverride;
   force?: boolean;
-  origin?: 'operator' | 'mount-continuation';
+  origin?: 'operator' | 'workflow' | 'mount-continuation';
   retry?: {
     readonly attempt: number;
     readonly provider: ProviderId;
@@ -243,7 +244,12 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     if (!isFrozenTargetHeld) {
       throw new Error('the branch mount this turn was queued on changed before it could start');
     }
-    const activeMount = aimedMount ?? selectActiveMount({ state: before, sessionId }) ?? undefined;
+    const selectedMount = aimedMount ?? selectActiveMount({ state: before, sessionId });
+    const isAutomaticTurn = origin === 'workflow' || origin === 'mount-continuation';
+    const activeMount =
+      selectedMount ??
+      (isAutomaticTurn ? selectAutomaticTurnMount({ state: before, sessionId }) : null) ??
+      undefined;
     if (activeMount === undefined && writableMounts.length > 0) {
       throw new Error('Choose the branch mount this session writes to before sending a turn.');
     }
@@ -1398,6 +1404,8 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
             ...(attachments !== undefined && { attachments }),
             ...(override !== undefined && { override }),
             ...(force === true ? { force: true } : {}),
+            ...(origin !== undefined && { origin }),
+            ...(turnTarget !== null && { mountTarget: turnTarget }),
             retry: {
               attempt: (retry?.attempt ?? 0) + 1,
               provider: fallbackPlan.provider,
@@ -1438,6 +1446,8 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
               content,
               ...(override !== undefined && { override }),
               ...(force === true ? { force: true } : {}),
+              ...(origin !== undefined && { origin }),
+              ...(turnTarget !== null && { mountTarget: turnTarget }),
               retry: {
                 attempt: 0,
                 provider,

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
@@ -67,6 +67,13 @@ const AGENT_ID = 'agent-step' as AgentId;
 const STEP_ID = 's-exec' as StepId;
 const NOW = '2026-05-23T00:00:00.000Z' as IsoDateTime;
 
+type SendTurnInput = {
+  readonly sessionId: SessionId;
+  readonly agentId: AgentId;
+  readonly content: string;
+  readonly origin?: 'workflow';
+};
+
 function makePlan(overrides: Partial<PlanWithCount> = {}): PlanWithCount {
   return {
     id: PLAN_ID,
@@ -146,9 +153,7 @@ function buildHarness(opts: {
     createdAt: NOW,
     updatedAt: NOW,
   };
-  const sendTurn = vi.fn(
-    async (_arg: { sessionId: SessionId; agentId: AgentId; content: string }) => undefined,
-  );
+  const sendTurn = vi.fn(async (_arg: SendTurnInput) => undefined);
   const state = {
     sessionPhaseRuns: { [SESSION_ID]: [opts.agent, ...(opts.extraAgents ?? [])] },
     sessions: [session],
@@ -282,6 +287,20 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
     expect(payload.content).toContain('do the thing');
     expect(payload.content).toContain('run the step');
     expect(fanOutClustersSpy).not.toHaveBeenCalled();
+  });
+
+  it('awaits the workflow kickoff and identifies its origin', async () => {
+    const { sendTurn, activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan()],
+    });
+    sendTurn.mockRejectedValueOnce(new Error('kickoff failed'));
+
+    await expect(activate({ sessionId: SESSION_ID, agentId: AGENT_ID })).rejects.toThrow(
+      'kickoff failed',
+    );
+    expect(sendTurn).toHaveBeenCalledWith(expect.objectContaining({ origin: 'workflow' }));
   });
 
   it('a reviewer step is passthrough: no consumption, no plan body injected', async () => {

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
@@ -164,7 +164,7 @@ export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
       composeStepBoundary(agentId),
     );
     if (kickoff.length > 0) {
-      void get().sendTurn({ sessionId, agentId, content: kickoff });
+      await get().sendTurn({ sessionId, agentId, content: kickoff, origin: 'workflow' });
     }
   };
 };

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
@@ -202,7 +202,7 @@ function startChild({
     clusterStartAttempts: { ...s.clusterStartAttempts, [childId]: attempt },
   }));
   void get()
-    .sendTurn({ sessionId, agentId: childId, content })
+    .sendTurn({ sessionId, agentId: childId, content, origin: 'workflow' })
     .catch((error: unknown) => {
       void handleChildStartFailure({
         set,

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
@@ -35,7 +35,7 @@ const startStep = (
       [agentId]: { kind: 'idle' as const, lastActivityAt: nowIso() },
     },
   }));
-  void get().sendTurn({ sessionId, agentId, content });
+  void get().sendTurn({ sessionId, agentId, content, origin: 'workflow' });
 };
 
 export const finalizeWorkflowStep = (set: SetFn, get: GetFn) => {

--- a/apps/desktop/src/store/slices/workflows/recoverStuckStep.ts
+++ b/apps/desktop/src/store/slices/workflows/recoverStuckStep.ts
@@ -56,6 +56,7 @@ export const recoverStuckStep = (get: GetFn) => {
         sessionId,
         agentId: agent.id,
         content: recoveryPrompt({ agentId: agent.id }),
+        origin: 'workflow',
       });
     } catch (error) {
       void get().emitNotification(

--- a/apps/desktop/src/store/slices/workflows/scoutTree.ts
+++ b/apps/desktop/src/store/slices/workflows/scoutTree.ts
@@ -210,7 +210,7 @@ const activateAgent = ({
       [agentId]: { kind: 'idle' as const, lastActivityAt: nowIso() },
     },
   }));
-  void get().sendTurn({ sessionId, agentId, content });
+  void get().sendTurn({ sessionId, agentId, content, origin: 'workflow' });
 };
 
 const areDisjointModules = (modules: ReadonlyArray<string>): boolean => {

--- a/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.test.ts
+++ b/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  IsoDateTime,
+  MountId,
+  Project,
+  ProjectId,
+  Session,
+  SessionId,
+  WorkspaceId,
+} from '@goodboy/types';
+import type { SessionWorktree } from '@goodboy/db';
+import type { AppStore } from '../../store';
+import type { GetFn, SetFn } from './types';
+
+type ReconcileParams = {
+  readonly sessions: ReadonlyArray<Session>;
+};
+
+type VerifyParams = {
+  readonly candidates: ReadonlyArray<SessionWorktree>;
+};
+
+const h = vi.hoisted(() => ({
+  sessions: [] as ReadonlyArray<Session>,
+  worktrees: new Map<SessionId, ReadonlyArray<SessionWorktree>>(),
+  projects: [] as ReadonlyArray<Project>,
+  updateSessionWriteDestination: vi.fn(async () => undefined),
+}));
+
+vi.mock('@goodboy/db', () => ({
+  listAgentsForSessions: vi.fn(async () => new Map()),
+  listExternalTasksForWorkspace: vi.fn(async () => []),
+  listProjectsForWorkspace: vi.fn(async () => h.projects),
+  listSessionsForWorkspace: vi.fn(async () => h.sessions),
+  listWorktreesForSessions: vi.fn(async () => h.worktrees),
+  setSetting: vi.fn(async () => undefined),
+  summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
+  summarizeWorkspaceTelemetry: vi.fn(async () => null),
+  touchWorkspaceLastAccessed: vi.fn(async () => undefined),
+  updateSessionActiveProject: vi.fn(async () => undefined),
+  updateSessionWriteDestination: h.updateSessionWriteDestination,
+}));
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+vi.mock('../../../features/chat/turn', () => ({
+  cancelTurn: vi.fn(async () => undefined),
+  listLiveRunIds: vi.fn(async () => []),
+}));
+vi.mock('../../../features/workspace/window', () => ({ isMainWindow: () => false }));
+vi.mock('../../../features/budget/budget', () => ({
+  invokeBudgetAlertsList: vi.fn(async () => []),
+  invokeBudgetRuleList: vi.fn(async () => []),
+}));
+vi.mock('../../../features/skills/skills', () => ({
+  invokeSkillList: vi.fn(async () => []),
+}));
+vi.mock('../../../features/workflows/workflows', () => ({
+  invokeStepDefList: vi.fn(async () => []),
+  invokeWorkflowList: vi.fn(async () => []),
+  invokeWorkflowsForSession: vi.fn(async () => []),
+}));
+vi.mock('../sessions/reconcileSessionRuns', () => ({
+  reconcileLoadedAgent: vi.fn(),
+  reconcileLoadedSessions: vi.fn(async ({ sessions }: ReconcileParams) => sessions),
+}));
+vi.mock('../project-mounts/verifyAvailableWorktrees', () => ({
+  verifyAvailableWorktrees: vi.fn(async ({ candidates }: VerifyParams) => candidates),
+}));
+vi.mock('../transcripts/buffer', () => ({ clearPendingTurnEvents: vi.fn() }));
+
+import { setCurrentWorkspace } from './setCurrentWorkspace';
+
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const PROJECT_ID = 'project-1' as ProjectId;
+const UNSELECTED_SESSION_ID = 'session-unselected' as SessionId;
+const RESTORED_SESSION_ID = 'session-restored' as SessionId;
+const REPAIRED_SESSION_ID = 'session-repaired' as SessionId;
+const RESTORED_MOUNT_ID = 'mount-restored-b' as MountId;
+const REPAIRED_MOUNT_ID = 'mount-repaired' as MountId;
+const NOW = '2026-09-12T00:00:00.000Z' as IsoDateTime;
+
+const overrides = {
+  defaultProviderId: null,
+  defaultWorkflowId: null,
+  defaultBranchPrefix: null,
+  parallelEnabled: null,
+  defaultVerbosity: null,
+  providerBindings: null,
+  taskModels: null,
+  roleModels: null,
+  parallelAgents: null,
+  providerPool: null,
+  attributionFooter: null,
+} satisfies Project['overrides'];
+
+const project: Project = {
+  id: PROJECT_ID,
+  workspaceId: WORKSPACE_ID,
+  name: 'app',
+  rootPath: '/repos/app',
+  kind: 'repo',
+  baseBranch: 'main',
+  overrides,
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+type SessionParams = {
+  readonly id: SessionId;
+  readonly activeMountId?: MountId;
+};
+
+const session = ({ id, activeMountId }: SessionParams): Session => ({
+  id,
+  workspaceId: WORKSPACE_ID,
+  goal: 'goal',
+  state: { kind: 'idle', lastActivityAt: NOW },
+  contextSlots: [],
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+  permissionMode: 'default',
+  workflowRuns: [],
+  autoRun: false,
+  titleUserEdited: false,
+  ...(activeMountId !== undefined && { activeMountId }),
+  createdAt: NOW,
+  updatedAt: NOW,
+});
+
+type WorktreeParams = {
+  readonly id: string;
+  readonly sessionId: SessionId;
+  readonly parallelIndex: number;
+};
+
+const worktree = ({ id, sessionId, parallelIndex }: WorktreeParams): SessionWorktree => ({
+  id,
+  sessionId,
+  worktreePath: `/repos/app/.goodboy/worktrees/${id}`,
+  branch: `feature/${id}`,
+  parallelIndex,
+  projectId: PROJECT_ID,
+  mountName: id,
+  revision: 0,
+  createdAt: 0,
+});
+
+type Harness = {
+  readonly state: AppStore;
+  readonly set: SetFn;
+  readonly get: GetFn;
+};
+
+const harness = (): Harness => {
+  let state = {
+    workspaces: [{ id: WORKSPACE_ID, lastAccessedAt: NOW }],
+    sessions: [],
+    projects: [],
+    currentWorkspaceId: null,
+    currentSessionId: null,
+    loadIntegrations: vi.fn(async () => undefined),
+    loadWorkspaceOverrides: vi.fn(),
+    refreshUnreadWorkspaces: vi.fn(),
+  } as unknown as AppStore;
+  const set: SetFn = (update) => {
+    const patch = typeof update === 'function' ? update(state) : update;
+    state = { ...state, ...patch };
+  };
+  return {
+    get state() {
+      return state;
+    },
+    set,
+    get: () => state,
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.projects = [project];
+  h.sessions = [
+    session({ id: UNSELECTED_SESSION_ID }),
+    session({ id: RESTORED_SESSION_ID, activeMountId: RESTORED_MOUNT_ID }),
+    session({ id: REPAIRED_SESSION_ID }),
+  ];
+  h.worktrees = new Map<SessionId, ReadonlyArray<SessionWorktree>>([
+    [
+      UNSELECTED_SESSION_ID,
+      [
+        worktree({ id: 'mount-unselected-a', sessionId: UNSELECTED_SESSION_ID, parallelIndex: 0 }),
+        worktree({ id: 'mount-unselected-b', sessionId: UNSELECTED_SESSION_ID, parallelIndex: 1 }),
+      ],
+    ],
+    [
+      RESTORED_SESSION_ID,
+      [
+        worktree({ id: 'mount-restored-a', sessionId: RESTORED_SESSION_ID, parallelIndex: 0 }),
+        worktree({ id: RESTORED_MOUNT_ID, sessionId: RESTORED_SESSION_ID, parallelIndex: 1 }),
+      ],
+    ],
+    [
+      REPAIRED_SESSION_ID,
+      [worktree({ id: REPAIRED_MOUNT_ID, sessionId: REPAIRED_SESSION_ID, parallelIndex: 0 })],
+    ],
+  ]);
+});
+
+describe('setCurrentWorkspace mount hydration', () => {
+  it('omits an unselected entry while retaining restored and repaired entries', async () => {
+    const store = harness();
+
+    await setCurrentWorkspace(store.set, store.get)(WORKSPACE_ID);
+
+    expect(store.state.sessionActiveMount[UNSELECTED_SESSION_ID]).toBeUndefined();
+    expect(store.state.sessionActiveMount[RESTORED_SESSION_ID]).toBe(RESTORED_MOUNT_ID);
+    expect(store.state.sessionActiveMount[REPAIRED_SESSION_ID]).toBe(REPAIRED_MOUNT_ID);
+  });
+});

--- a/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.ts
+++ b/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.ts
@@ -160,7 +160,9 @@ export const setCurrentWorkspace = (set: SetFn, get: GetFn) => {
             });
           }
         } else {
-          sessionActiveMount[s.id] = s.activeMountId ?? null;
+          if (s.activeMountId != null) {
+            sessionActiveMount[s.id] = s.activeMountId;
+          }
           if (
             s.activeProjectId != null &&
             mounts.some((mount) => mount.projectId === s.activeProjectId)

--- a/apps/desktop/src/store/store.story-worktree-cardinality.test.ts
+++ b/apps/desktop/src/store/store.story-worktree-cardinality.test.ts
@@ -177,12 +177,24 @@ describe('story: two mounts of one project survive a restart', () => {
     await useAppStore.getState().setCurrentWorkspace(WORKSPACE_ID);
 
     const state = useAppStore.getState();
-    expect(state.sessionActiveMount[SESSION_ID]).toBeNull();
+    expect(state.sessionActiveMount[SESSION_ID]).toBeUndefined();
     expect(state.sessionBranches[SESSION_ID]).toBeUndefined();
     expect(storySpies.updateSessionWriteDestination).not.toHaveBeenCalled();
     await expect(
       useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'go' }),
     ).rejects.toThrow(/Choose the branch mount/);
+  });
+
+  it('lets a workflow turn resolve the mount without a choice', async () => {
+    await seed({ session: sessionWith(), rows: ROWS });
+
+    await useAppStore.getState().setCurrentWorkspace(WORKSPACE_ID);
+
+    await expect(
+      useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'go', origin: 'workflow' }),
+    ).rejects.toThrow(/no agent selected/);
+    expect(useAppStore.getState().sessionActiveMount[SESSION_ID]).toBeUndefined();
+    expect(storySpies.updateSessionWriteDestination).not.toHaveBeenCalled();
   });
 
   it('repairs and persists the choice when the session holds a single mount', async () => {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -597,7 +597,7 @@ type AppActions = {
     attachments?: ReadonlyArray<AttachmentInput>;
     override?: TurnProviderOverride;
     force?: boolean;
-    origin?: 'operator';
+    origin?: 'operator' | 'workflow';
   }): Promise<SendTurnResult>;
   cancelCurrentTurn(sessionId: SessionId, agentId?: AgentId): Promise<void>;
   retrySummarizer(sessionId: SessionId, taskModelOverride?: TaskModelPreference): void;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.2.28',
+  version: 'v0.2.29',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
Version bump to 0.2.29 across the six places that carry it, with the `## Goodboy v0.2.29` changelog section the release build reads.

Contents since v0.2.28: [#1754](https://github.com/akhayam99/goodboy/pull/1754), workflow steps resolve their own write mount instead of stopping on a session with more than one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)