### PR TITLE
feat(desktop): let a turn write in every project the session mounts

### DIFF
--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -264,6 +264,14 @@ fn build_provider_cli_args(binary: &str, args: &SpawnOneArgs<'_>) -> Vec<String>
                 "--setting-sources".to_string(),
                 crate::aux_spawn::CLAUDE_SETTING_SOURCES.to_string(),
             ]);
+            for root in args.writable_roots {
+                v.push("--add-dir".to_string());
+                v.push(root.to_string());
+            }
+            if let Some(socket_directory) = args.query_socket_directory {
+                v.push("--add-dir".to_string());
+                v.push(socket_directory.to_string());
+            }
             if let Some(sp) = args.system_prompt {
                 v.push("--append-system-prompt".to_string());
                 v.push(sp.to_string());
@@ -795,13 +803,21 @@ mod tests {
     }
 
     #[test]
-    fn claude_args_ignore_writable_directories() {
+    fn claude_args_add_writable_directories() {
         let empty: Vec<String> = vec![];
-        let roots = vec!["/repo/one/.git".to_string()];
+        let roots = vec!["/repo/one/.git".to_string(), "/repo/two/.git".to_string()];
         let mut args = make_args(None, None, &empty);
         args.writable_roots = &roots;
         let cli = build_provider_cli_args("claude", &args);
-        assert!(!cli.iter().any(|arg| arg == "--add-dir"));
+        let added_directories: Vec<&str> = cli
+            .windows(2)
+            .filter(|pair| pair[0] == "--add-dir")
+            .map(|pair| pair[1].as_str())
+            .collect();
+        assert_eq!(
+            added_directories,
+            vec!["/repo/one/.git", "/repo/two/.git", "/tmp/goodboy-query"]
+        );
     }
 
     #[test]

--- a/apps/desktop/src/features/chat/components/WriteDestinationControl/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/WriteDestinationControl/index.test.tsx
@@ -103,7 +103,7 @@ describe('WriteDestinationControl', () => {
     expect(screen.getByText('Runs in: web / main / ak/feat-thing')).toBeDefined();
     expect(
       screen.getByTitle(
-        'Turns run in web / main / ak/feat-thing (/sessions/one/main). They can still write in every mounted project.',
+        'Turns run in web / main / ak/feat-thing (/sessions/one/main). They can still write in every repository this session mounts.',
       ),
     ).toBeDefined();
   });
@@ -118,7 +118,7 @@ describe('WriteDestinationControl', () => {
     await waitFor(() => {
       expect(
         screen.getByTitle(
-          'Turns run in session scratch folder (/goodboy/scratch/session-1). They can still write in every mounted project.',
+          'Turns run in session scratch folder (/goodboy/scratch/session-1). They can still write in every repository this session mounts.',
         ),
       ).toBeDefined();
     });
@@ -186,7 +186,7 @@ describe('WriteDestinationControl', () => {
     expect(screen.getByText('Working folder')).toBeDefined();
     expect(
       screen.getByText(
-        'Commands and git run here. A turn can write in every project this session mounts.',
+        'Commands and git run here. A turn can write in every repository this session mounts.',
       ),
     ).toBeDefined();
     fireEvent.click(screen.getByText('web / feature'));
@@ -273,7 +273,7 @@ describe('WriteDestinationControl with siblings and no choice', () => {
     expect(screen.getByText('Auto: web / feature / ak/two')).toBeDefined();
     expect(
       screen.getByTitle(
-        'Nobody chose a folder, so turns run in web / feature / ak/two (/sessions/one/feature). They can still write in every mounted project.',
+        'Nobody chose a folder, so turns run in web / feature / ak/two (/sessions/one/feature). They can still write in every repository this session mounts.',
       ),
     ).toBeDefined();
     expect(screen.getByRole('button', { name: /Working folder/ })).toBeDefined();

--- a/apps/desktop/src/features/chat/components/WriteDestinationControl/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/WriteDestinationControl/index.test.tsx
@@ -92,7 +92,7 @@ describe('WriteDestinationControl', () => {
   });
   afterEach(cleanup);
 
-  it('shows the resolved mount as the write destination', () => {
+  it('shows the resolved mount as the working folder', () => {
     store.sessionProjectMounts = {
       [SESSION_ID]: [mount({ mountId: MOUNT_MAIN, mountName: 'main', branch: 'ak/feat-thing' })],
     };
@@ -100,22 +100,26 @@ describe('WriteDestinationControl', () => {
 
     render(<WriteDestinationControl sessionId={SESSION_ID} agentId={AGENT_ID} />);
 
-    expect(screen.getByText('Write to: web / main / ak/feat-thing')).toBeDefined();
+    expect(screen.getByText('Runs in: web / main / ak/feat-thing')).toBeDefined();
     expect(
-      screen.getByTitle('Writing to web / main / ak/feat-thing (/sessions/one/main)'),
+      screen.getByTitle(
+        'Turns run in web / main / ak/feat-thing (/sessions/one/main). They can still write in every mounted project.',
+      ),
     ).toBeDefined();
   });
 
   it('falls back to the session scratch folder when there are no mounted projects', async () => {
     render(<WriteDestinationControl sessionId={SESSION_ID} agentId={AGENT_ID} />);
 
-    expect(screen.getByText('Write to: session scratch folder')).toBeDefined();
-    const trigger = screen.getByRole('button', { name: /Write destination/ }) as HTMLButtonElement;
+    expect(screen.getByText('Session folder')).toBeDefined();
+    const trigger = screen.getByRole('button', { name: /Working folder/ }) as HTMLButtonElement;
     expect(trigger.disabled).toBe(true);
 
     await waitFor(() => {
       expect(
-        screen.getByTitle('Writing to session scratch folder (/goodboy/scratch/session-1)'),
+        screen.getByTitle(
+          'Turns run in session scratch folder (/goodboy/scratch/session-1). They can still write in every mounted project.',
+        ),
       ).toBeDefined();
     });
   });
@@ -161,7 +165,7 @@ describe('WriteDestinationControl', () => {
 
     expect(
       screen.getByTitle(
-        'This turn and the next ones write to web / main / ak/feat-thing (/sessions/one/main).',
+        'This turn and the next ones run in web / main / ak/feat-thing (/sessions/one/main).',
       ),
     ).toBeDefined();
     expect(screen.queryByText(/^Next:/)).toBeNull();
@@ -178,7 +182,13 @@ describe('WriteDestinationControl', () => {
 
     render(<WriteDestinationControl sessionId={SESSION_ID} agentId={AGENT_ID} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /Write destination/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Working folder/ }));
+    expect(screen.getByText('Working folder')).toBeDefined();
+    expect(
+      screen.getByText(
+        'Commands and git run here. A turn can write in every project this session mounts.',
+      ),
+    ).toBeDefined();
     fireEvent.click(screen.getByText('web / feature'));
     expect(store.setSessionActiveMount).not.toHaveBeenCalled();
 
@@ -206,25 +216,31 @@ describe('WriteDestinationControl with siblings and no choice', () => {
     store.agentTurnDestination = {};
     store.sessionProjectMounts = {
       [SESSION_ID]: [
-        mount({ mountId: MOUNT_MAIN, mountName: 'main', branch: 'ak/one' }),
-        mount({ mountId: MOUNT_FEATURE, mountName: 'feature', branch: 'ak/two' }),
+        {
+          ...mount({ mountId: MOUNT_MAIN, mountName: 'main', branch: 'ak/one' }),
+          parallelIndex: 1,
+        },
+        {
+          ...mount({ mountId: MOUNT_FEATURE, mountName: 'feature', branch: 'ak/two' }),
+          parallelIndex: 2,
+        },
       ],
     };
   });
   afterEach(cleanup);
 
-  it('asks for a destination instead of naming the scratch folder', () => {
+  it('names the automatic mount instead of the scratch folder', () => {
     render(<WriteDestinationControl sessionId={SESSION_ID} agentId={AGENT_ID} />);
 
-    expect(screen.getByText('Choose destination')).toBeDefined();
+    expect(screen.getByText('Auto: web / main / ak/one')).toBeDefined();
     expect(screen.queryByText(/scratch folder/)).toBeNull();
     expect(scratchDirPrepare).not.toHaveBeenCalled();
   });
 
-  it('writes the chosen mount as the destination of the next turns', async () => {
+  it('sets the chosen mount as the working folder of the next turns', async () => {
     render(<WriteDestinationControl sessionId={SESSION_ID} agentId={AGENT_ID} />);
 
-    fireEvent.click(screen.getByText('Choose destination'));
+    fireEvent.click(screen.getByText('Auto: web / main / ak/one'));
     fireEvent.click(screen.getByText('web / feature'));
     fireEvent.click(screen.getByText('Use for next turns of the session'));
 
@@ -257,9 +273,9 @@ describe('WriteDestinationControl with siblings and no choice', () => {
     expect(screen.getByText('Auto: web / feature / ak/two')).toBeDefined();
     expect(
       screen.getByTitle(
-        'No mount chosen for this session. Automated turns write to web / feature / ak/two (/sessions/one/feature) until you choose one.',
+        'Nobody chose a folder, so turns run in web / feature / ak/two (/sessions/one/feature). They can still write in every mounted project.',
       ),
     ).toBeDefined();
-    expect(screen.getByRole('button', { name: /Write destination/ })).toBeDefined();
+    expect(screen.getByRole('button', { name: /Working folder/ })).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/chat/components/WriteDestinationControl/index.tsx
+++ b/apps/desktop/src/features/chat/components/WriteDestinationControl/index.tsx
@@ -57,9 +57,9 @@ export const WriteDestinationControl = ({ sessionId, agentId, fallback }: Props)
         : `In progress and next turns: ${nextLabel}`;
 
   const primaryTitle = isAutomatic
-    ? `Nobody chose a folder, so turns run in ${nextDetail}. They can still write in every mounted project.`
+    ? `Nobody chose a folder, so turns run in ${nextDetail}. They can still write in every repository this session mounts.`
     : running === null
-      ? `Turns run in ${nextDetail}. They can still write in every mounted project.`
+      ? `Turns run in ${nextDetail}. They can still write in every repository this session mounts.`
       : diverges
         ? `This turn started in ${runningDetail}. Next turns run in ${nextDetail} unless changed.`
         : `This turn and the next ones run in ${nextDetail}.`;
@@ -124,7 +124,7 @@ export const WriteDestinationControl = ({ sessionId, agentId, fallback }: Props)
           <div className="flex flex-col gap-1">
             <span className="text-sm font-semibold text-foreground">Working folder</span>
             <span className="text-2xs text-muted-foreground">
-              Commands and git run here. A turn can write in every project this session mounts.
+              Commands and git run here. A turn can write in every repository this session mounts.
             </span>
           </div>
 

--- a/apps/desktop/src/features/chat/components/WriteDestinationControl/index.tsx
+++ b/apps/desktop/src/features/chat/components/WriteDestinationControl/index.tsx
@@ -46,27 +46,23 @@ export const WriteDestinationControl = ({ sessionId, agentId, fallback }: Props)
   const nextDetail = writeDestinationDetail(next);
   const runningDetail = running === null ? null : writeDestinationDetail(running);
 
-  const isUnselected = next.kind === 'unselected';
-
   const primaryLabel = isAutomatic
     ? `Auto: ${nextLabel}`
-    : isUnselected
-      ? 'Choose destination'
-      : running === null
-        ? `Write to: ${nextLabel}`
-        : diverges
-          ? `In progress: ${runningLabel}`
-          : `In progress and next turns: ${nextLabel}`;
+    : running === null
+      ? next.kind === 'scratch'
+        ? 'Session folder'
+        : `Runs in: ${nextLabel}`
+      : diverges
+        ? `In progress: ${runningLabel}`
+        : `In progress and next turns: ${nextLabel}`;
 
   const primaryTitle = isAutomatic
-    ? `No mount chosen for this session. Automated turns write to ${nextDetail} until you choose one.`
-    : isUnselected
-      ? nextDetail
-      : running === null
-        ? `Writing to ${nextDetail}`
-        : diverges
-          ? `This turn started on ${runningDetail}. Next turns write to ${nextDetail} unless changed.`
-          : `This turn and the next ones write to ${nextDetail}.`;
+    ? `Nobody chose a folder, so turns run in ${nextDetail}. They can still write in every mounted project.`
+    : running === null
+      ? `Turns run in ${nextDetail}. They can still write in every mounted project.`
+      : diverges
+        ? `This turn started in ${runningDetail}. Next turns run in ${nextDetail} unless changed.`
+        : `This turn and the next ones run in ${nextDetail}.`;
 
   const Icon = next.kind === 'scratch' ? CONCEPT_ICONS.folderOpen : CONCEPT_ICONS.worktree;
   const hasCandidates = candidates.length > 0;
@@ -100,13 +96,13 @@ export const WriteDestinationControl = ({ sessionId, agentId, fallback }: Props)
   const trigger = (
     <Chip
       as="button"
-      tone={isAutomatic || diverges || isUnselected ? 'warning' : 'neutral'}
+      tone={isAutomatic || diverges ? 'warning' : 'neutral'}
       size="xs"
       bordered={false}
       icon={<Icon size={ICON_SIZE.row} aria-hidden />}
       label={<span className="max-w-[16rem] truncate">{shorten(primaryLabel)}</span>}
       title={primaryTitle}
-      ariaLabel={`Write destination. ${primaryTitle}`}
+      ariaLabel={`Working folder. ${primaryTitle}`}
       hasPopup="dialog"
       expanded={dropdown.open}
       onClick={openPicker}
@@ -120,17 +116,15 @@ export const WriteDestinationControl = ({ sessionId, agentId, fallback }: Props)
       <AnchoredPopover
         dropdown={dropdown}
         role="dialog"
-        ariaLabel="Choose write destination"
+        ariaLabel="Choose working folder"
         anchorClassName="shrink-0"
         trigger={trigger}
       >
         <div className="flex flex-col gap-3 p-3">
           <div className="flex flex-col gap-1">
-            <span className="text-sm font-semibold text-foreground">Write destination</span>
+            <span className="text-sm font-semibold text-foreground">Working folder</span>
             <span className="text-2xs text-muted-foreground">
-              {isUnselected
-                ? 'This session has more than one branch mount. Pick the one the next turns write to.'
-                : 'Applies to the next turns of this session, for every agent.'}
+              Commands and git run here. A turn can write in every project this session mounts.
             </span>
           </div>
 
@@ -179,7 +173,7 @@ export const WriteDestinationControl = ({ sessionId, agentId, fallback }: Props)
           size="3xs"
           bordered={false}
           label={<span className="max-w-[10rem] truncate">{`Next: ${shorten(nextLabel)}`}</span>}
-          title={`Next turns write to ${nextDetail}.`}
+          title={`Next turns run in ${nextDetail}.`}
         />
       ) : null}
     </span>

--- a/apps/desktop/src/features/chat/components/WriteDestinationControl/useWriteDestination/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/WriteDestinationControl/useWriteDestination/index.test.tsx
@@ -127,7 +127,6 @@ describe('useWriteDestination, subscription scope', () => {
       const view = useWriteDestination({
         sessionId: SESSION_ID,
         agentId: AGENT_ID,
-        fallback: 'automatic',
       });
       selectedMountId = view.next.kind === 'mount' ? view.next.mountId : null;
       isAutomatic = view.isAutomatic;

--- a/apps/desktop/src/features/chat/components/WriteDestinationControl/useWriteDestination/index.ts
+++ b/apps/desktop/src/features/chat/components/WriteDestinationControl/useWriteDestination/index.ts
@@ -32,7 +32,7 @@ export type WriteDestinationView = Readonly<{
 export const useWriteDestination = ({
   sessionId,
   agentId,
-  fallback,
+  fallback = 'automatic',
 }: Params): WriteDestinationView => {
   const session = useAppStore((state) =>
     state.sessions.find((candidate) => candidate.id === sessionId),
@@ -123,7 +123,6 @@ export const useWriteDestination = ({
         mount: nextMount,
         projectName: activeProjectName,
         scratchPath,
-        mountCount: writableMounts.length,
       }),
     [nextMount, activeProjectName, scratchPath, writableMounts],
   );

--- a/apps/desktop/src/store/slices/project-mounts/writeDestination.test.ts
+++ b/apps/desktop/src/store/slices/project-mounts/writeDestination.test.ts
@@ -80,7 +80,6 @@ describe('resolveWriteDestination', () => {
       mount: repoMount,
       projectName: 'web',
       scratchPath: null,
-      mountCount: 1,
     });
     expect(destination).toEqual({
       kind: 'mount',
@@ -100,7 +99,6 @@ describe('resolveWriteDestination', () => {
       mount: folderMount,
       projectName: 'notes',
       scratchPath: null,
-      mountCount: 1,
     });
     expect(destination.kind === 'mount' && destination.hasGit).toBe(false);
     expect(writeDestinationLabel(destination)).toBe('notes / working folder / no git');
@@ -111,21 +109,9 @@ describe('resolveWriteDestination', () => {
       mount: null,
       projectName: null,
       scratchPath: '/goodboy/scratch/session-1',
-      mountCount: 0,
     });
     expect(destination).toEqual({ kind: 'scratch', path: '/goodboy/scratch/session-1' });
     expect(writeDestinationLabel(destination)).toBe('session scratch folder');
-  });
-
-  it('refuses the scratch folder when the session holds mounts but chose none', () => {
-    const destination = resolveWriteDestination({
-      mount: null,
-      projectName: null,
-      scratchPath: '/goodboy/scratch/session-1',
-      mountCount: 2,
-    });
-    expect(destination).toEqual({ kind: 'unselected', mountCount: 2 });
-    expect(writeDestinationLabel(destination)).toBe('no destination chosen');
   });
 });
 
@@ -141,13 +127,11 @@ describe('writeDestinationsMatch', () => {
       mount: repoMount,
       projectName: 'web',
       scratchPath: null,
-      mountCount: 1,
     });
     const b = resolveWriteDestination({
       mount: { ...repoMount, branch: 'ak/other' },
       projectName: 'web',
       scratchPath: null,
-      mountCount: 1,
     });
     expect(writeDestinationsMatch(a, b)).toBe(true);
   });
@@ -157,13 +141,11 @@ describe('writeDestinationsMatch', () => {
       mount: repoMount,
       projectName: 'web',
       scratchPath: null,
-      mountCount: 1,
     });
     const scratch = resolveWriteDestination({
       mount: null,
       projectName: null,
       scratchPath: null,
-      mountCount: 0,
     });
     expect(writeDestinationsMatch(mount, scratch)).toBe(false);
   });
@@ -173,25 +155,13 @@ describe('writeDestinationsMatch', () => {
       mount: repoMount,
       projectName: 'web',
       scratchPath: null,
-      mountCount: 2,
     });
     const sibling = resolveWriteDestination({
       mount: { ...repoMount, mountId: 'mount-web-second' as MountId },
       projectName: 'web',
       scratchPath: null,
-      mountCount: 2,
     });
     expect(writeDestinationsMatch(a, sibling)).toBe(false);
-  });
-
-  it('never matches an unselected destination, not even with itself', () => {
-    const unselected = resolveWriteDestination({
-      mount: null,
-      projectName: null,
-      scratchPath: '/goodboy/scratch/session-1',
-      mountCount: 2,
-    });
-    expect(writeDestinationsMatch(unselected, unselected)).toBe(false);
   });
 });
 

--- a/apps/desktop/src/store/slices/project-mounts/writeDestination.ts
+++ b/apps/desktop/src/store/slices/project-mounts/writeDestination.ts
@@ -16,10 +16,7 @@ export type WriteDestinationCandidate = WriteDestinationMount;
 
 export type WriteDestinationScratch = Readonly<{ kind: 'scratch'; path: string | null }>;
 
-export type WriteDestinationUnselected = Readonly<{ kind: 'unselected'; mountCount: number }>;
-
-export type WriteDestination =
-  WriteDestinationMount | WriteDestinationScratch | WriteDestinationUnselected;
+export type WriteDestination = WriteDestinationMount | WriteDestinationScratch;
 
 type DescribeMountParams = {
   readonly mount: SessionProjectMount;
@@ -41,20 +38,15 @@ type ResolveParams = {
   readonly mount: SessionProjectMount | null;
   readonly projectName: string | null;
   readonly scratchPath: string | null;
-  readonly mountCount: number;
 };
 
 export const resolveWriteDestination = ({
   mount,
   projectName,
   scratchPath,
-  mountCount,
 }: ResolveParams): WriteDestination => {
   if (mount !== null) {
     return describeMount({ mount, projectName: projectName ?? mount.mountName });
-  }
-  if (mountCount > 0) {
-    return { kind: 'unselected', mountCount };
   }
   return { kind: 'scratch', path: scratchPath };
 };
@@ -62,9 +54,6 @@ export const resolveWriteDestination = ({
 export const writeDestinationLabel = (destination: WriteDestination): string => {
   if (destination.kind === 'scratch') {
     return 'session scratch folder';
-  }
-  if (destination.kind === 'unselected') {
-    return 'no destination chosen';
   }
   if (!destination.hasGit) {
     return `${destination.projectName} / working folder / no git`;
@@ -74,17 +63,11 @@ export const writeDestinationLabel = (destination: WriteDestination): string => 
 
 export const writeDestinationDetail = (destination: WriteDestination): string => {
   const label = writeDestinationLabel(destination);
-  if (destination.kind === 'unselected') {
-    return `${label}. This session has ${destination.mountCount} branch mounts, choose the one the next turns write to.`;
-  }
   const path = destination.kind === 'scratch' ? destination.path : destination.worktreePath;
   return path === null ? label : `${label} (${path})`;
 };
 
 export const writeDestinationsMatch = (a: WriteDestination, b: WriteDestination): boolean => {
-  if (a.kind === 'unselected' || b.kind === 'unselected') {
-    return false;
-  }
   if (a.kind === 'scratch' && b.kind === 'scratch') {
     return true;
   }

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -227,7 +227,6 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     const workspaceProjects = before.projects.filter(
       (project) => project.workspaceId === session.workspaceId,
     );
-    const writableMounts = selectWritableMounts({ state: before, sessionId });
     const aimedMountId = mountTarget?.mountId ?? mountId;
     const aimedMount =
       aimedMountId === undefined
@@ -245,14 +244,8 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
       throw new Error('the branch mount this turn was queued on changed before it could start');
     }
     const selectedMount = aimedMount ?? selectActiveMount({ state: before, sessionId });
-    const isAutomaticTurn = origin === 'workflow' || origin === 'mount-continuation';
     const activeMount =
-      selectedMount ??
-      (isAutomaticTurn ? selectAutomaticTurnMount({ state: before, sessionId }) : null) ??
-      undefined;
-    if (activeMount === undefined && writableMounts.length > 0) {
-      throw new Error('Choose the branch mount this session writes to before sending a turn.');
-    }
+      selectedMount ?? selectAutomaticTurnMount({ state: before, sessionId }) ?? undefined;
     const turnTarget =
       activeMount === undefined
         ? null
@@ -300,7 +293,6 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
           mount: activeMount ?? null,
           projectName: turnDestinationProjectName,
           scratchPath: activeMount === undefined ? workingDir : null,
-          mountCount: writableMounts.length,
         }),
       },
     }));

--- a/apps/desktop/src/store/store.story-worktree-cardinality.test.ts
+++ b/apps/desktop/src/store/store.story-worktree-cardinality.test.ts
@@ -12,6 +12,8 @@ import type {
 import {
   buildStoryAgent,
   buildStorySession,
+  connectedAnthropicState,
+  emptyTurnStream,
   resetStorySpies,
   storyResolveQueries,
   storySpies,
@@ -171,18 +173,33 @@ describe('story: two mounts of one project survive a restart', () => {
     expect(state.sessionBranches[SESSION_ID]).toBe('ak/two');
   });
 
-  it('asks for a choice instead of writing into the first mount', async () => {
+  it('runs an unselected turn in the lowest-parallelIndex mount without persisting a choice', async () => {
     await seed({ session: sessionWith(), rows: ROWS });
 
     await useAppStore.getState().setCurrentWorkspace(WORKSPACE_ID);
+    const agent = buildStoryAgent({
+      id: 'agent-operator' as AgentId,
+      sessionId: SESSION_ID,
+      name: 'operator',
+    });
+    useAppStore.setState({
+      sessionPhaseRuns: { [SESSION_ID]: [agent] },
+      selectedAgentId: { [SESSION_ID]: agent.id },
+      ...connectedAnthropicState(),
+    });
+    storySpies.runTurn.mockImplementation(() => emptyTurnStream());
 
-    const state = useAppStore.getState();
-    expect(state.sessionActiveMount[SESSION_ID]).toBeUndefined();
-    expect(state.sessionBranches[SESSION_ID]).toBeUndefined();
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'go' });
+
+    expect(storySpies.runTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workingDir: pathOf({ mountId: MOUNT_A1 }),
+        mountId: MOUNT_A1,
+      }),
+    );
+    expect(useAppStore.getState().sessionActiveMount[SESSION_ID]).toBeUndefined();
+    expect(useAppStore.getState().sessionBranches[SESSION_ID]).toBeUndefined();
     expect(storySpies.updateSessionWriteDestination).not.toHaveBeenCalled();
-    await expect(
-      useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'go' }),
-    ).rejects.toThrow(/Choose the branch mount/);
   });
 
   it('lets a workflow turn resolve the mount without a choice', async () => {


### PR DESCRIPTION
## What was wrong

With more than one mount the scope guard tells the agent that file operations may resolve inside **any** of the session's mounts. Only the Codex branch of `build_provider_cli_args` acted on that: it passes every sibling worktree and git metadata directory as `--add-dir`. The Claude branch dropped them, pinned by a test named `claude_args_ignore_writable_directories`. So on Claude a step could not touch the session's second repository at all, and the guard's promise was prompt text.

The other half: `sendTurn` still refused to start a turn when the session had more than one mount and nobody had picked one. v0.2.29 made workflow turns resolve a mount by themselves; operator turns still hit `Choose the branch mount this session writes to before sending a turn.`

## What changes

**Claude receives the same writable roots as Codex.** Repeated `--add-dir` for each root and for the query socket directory, in every permission mode. The test now asserts they arrive, in order.

**The pick stops gating anything.** Every turn resolves a mount: the one you chose, otherwise the lowest `parallelIndex`. The error is gone, along with the `unselected` destination state that existed only to carry it.

**The control says what it controls.** It was never a permission boundary: it sets the directory commands and git run in. The chip reads `Runs in: …`, the popover is `Working folder`, and it states that a turn can write in every project the session mounts. Choosing one is an override, not a precondition.

## Scope

This does not yet move the cwd off the mounts, partition diff tracking and PR creation per mount, or acquire a writer lease per mount before spawning. Those come with the removal of the session-level destination, which needs a migration and lands separately. Cursor, the `agy` binary and the OpenCode-backed providers keep today's single-root behavior: their multi-root mechanisms differ and none is verified against an installed binary yet.

## Checks

`pnpm typecheck`, `pnpm lint`, `pnpm knip`, `pnpm knip:production`, `pnpm test` (1088 files), `cargo test --locked` (744 tests): all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)