### PR TITLE
chore(repo): bump version to 0.2.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.2.30
+
+A turn starts where the session already is, and on Claude it reaches the other
+repositories the session has open.
+
+### [#1756] Turns start without asking which folder
+
+A session holding more than one repository used to refuse every turn until you
+picked the folder it would write in. A turn now starts in one of them and says
+which, and choosing a different one is something you do when you want it rather
+than a step you owe before any work begins.
+
+On Claude a turn can now also work in the session's other repositories, which
+until now only Codex could do. The control that used to ask for a write
+destination says what it actually sets: the folder where commands and git run.
+A project mounted as a plain folder rather than a repository stays outside that
+reach.
+
+Follow-up: which repository a turn touched is still read from that one folder,
+so changes in the others are not yet counted as part of the session.
+
 ## Goodboy v0.2.29
 
 A workflow that works across more than one repository keeps running instead of

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.2.29"
+version = "0.2.30"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.2.29',
+  version: 'v0.2.30',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
Version bump to 0.2.30 across the six places that carry it, with the `## Goodboy v0.2.30` changelog section the release build reads.

Contents since v0.2.29: [#1756](https://github.com/akhayam99/goodboy/pull/1756), a turn starts without asking which folder and, on Claude, reaches the session's other repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)